### PR TITLE
Fixed return type of functions open_* for macOS.

### DIFF
--- a/audio/al/al.go
+++ b/audio/al/al.go
@@ -12,7 +12,7 @@ The OpenAL documentation can be accessed at https://openal.org/documentation/
 package al
 
 /*
-#cgo darwin   CFLAGS:  -DGO_DARWIN
+#cgo darwin   CFLAGS:  -DGO_DARWIN  -I../include
 #cgo linux    CFLAGS:  -DGO_LINUX   -I../include
 #cgo windows  CFLAGS:  -DGO_WINDOWS -I../include
 #cgo darwin   LDFLAGS:

--- a/audio/al/loader.c
+++ b/audio/al/loader.c
@@ -36,12 +36,15 @@ static alProc get_proc(const char *proc) {
 CFBundleRef bundle;
 CFURLRef bundleURL;
 
-static void open_libal(void) {
+static int open_libal(void) {
 	bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault,
 		CFSTR("/System/Library/Frameworks/OpenAL.framework"),
 		kCFURLPOSIXPathStyle, true);
 	bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-	assert(bundle != NULL);
+	if (bundle == NULL) {
+		return -1;
+	}
+	return 0;
 }
 
 static void close_libal(void) {

--- a/audio/ov/loader.c
+++ b/audio/ov/loader.c
@@ -40,12 +40,15 @@ static alProc get_proc(const char *proc) {
 CFBundleRef bundle;
 CFURLRef bundleURL;
 
-static void open_libvbf(void) {
+static int open_libvbf(void) {
 	bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault,
 		CFSTR("/System/Library/Frameworks/OpenAL.framework"),
 		kCFURLPOSIXPathStyle, true);
 	bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-	assert(bundle != NULL);
+	if (bundle == NULL) {
+		return -1;
+	}
+	return 0;
 }
 
 static void close_libvbf(void) {

--- a/gls/glapi.c
+++ b/gls/glapi.c
@@ -60,14 +60,17 @@ CFBundleRef bundle;
 CFURLRef bundleURL;
 
 // open_libgl opens the OpenGL shared object for OSX
-static void open_libgl(void) {
+static int open_libgl(void) {
 
 	bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault,
 		CFSTR("/System/Library/Frameworks/OpenGL.framework"),
 		kCFURLPOSIXPathStyle, true);
 
 	bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-	assert(bundle != NULL);
+	if (bundle == NULL) {
+		return -1;
+	}
+	return 0;
 }
 
 // close_libgl closes the OpenGL shared object object for OSX


### PR DESCRIPTION
Fixed error for `go get ...` on macOS
```
 %go get -u -v github.com/g3n/engine/...
... skip ...
github.com/g3n/engine/gls
g3n/engine/gls/glapi.c:144:6: error: initializing 'int' with an expression of incompatible type 'void'
```