### PR TITLE
Added -I../include into CFLAGS for DARWIN.

### DIFF
--- a/audio/al/al.go
+++ b/audio/al/al.go
@@ -12,7 +12,7 @@ The OpenAL documentation can be accessed at https://openal.org/documentation/
 package al
 
 /*
-#cgo darwin   CFLAGS:  -DGO_DARWIN
+#cgo darwin   CFLAGS:  -DGO_DARWIN  -I../include
 #cgo linux    CFLAGS:  -DGO_LINUX   -I../include
 #cgo windows  CFLAGS:  -DGO_WINDOWS -I../include
 #cgo darwin   LDFLAGS:


### PR DESCRIPTION
Fixed error

```
 % go build ./...
# github.com/g3n/engine/audio/al
audio/al/al.go:24:10: fatal error: 'AL/al.h' file not found
#include "AL/al.h"
         ^
1 error generated.
```