### PR TITLE
Fixed forward-compatible contexts for OpenGL 3.2 on DARWIN.

### DIFF
--- a/window/glfw.go
+++ b/window/glfw.go
@@ -49,6 +49,7 @@ func newGLFW(width, height int, title string, full bool) (*GLFW, error) {
 		glfw.WindowHint(glfw.ContextVersionMinor, 3)
 		glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 		glfw.WindowHint(glfw.Samples, 8)
+		glfw.WindowHint(glfw.OpenGLForwardCompatible, 1)
 		initialized = true
 	}
 


### PR DESCRIPTION
Fixed error like 
```
 % ./gokoban
09:44:09.766599:I:Gokoban:Initializing Gokoban
panic: VersionUnavailable: NSGL: The targeted version of OS X only supports forward-compatible contexts for OpenGL 3.2 and above

goroutine 1 [running, locked to thread]:
main.main()
       .../go/src/github.com/danaugrs/gokoban/main.go:1287 +0x327
```