### PR TITLE
Implemented Axis Helper using a Geometry Shader

### DIFF
--- a/graphic/axis_helper.go
+++ b/graphic/axis_helper.go
@@ -19,27 +19,35 @@ func NewAxisHelper(size float32) *AxisHelper {
 
 	axis := new(AxisHelper)
 
+	vertexCount := 2
+
 	// Creates geometry with three orthogonal lines
 	// starting at the origin
 	geom := geometry.NewGeometry()
-	positions := math32.NewArrayF32(0, 18)
-	positions.Append(
-		0, 0, 0, size, 0, 0,
-		0, 0, 0, 0, size, 0,
-		0, 0, 0, 0, 0, size,
+
+	zero := math32.Vector3Zero
+	up := math32.Vector3Up.MultiplyScalar(size)
+	right := math32.Vector3Right.MultiplyScalar(size)
+	back := math32.Vector3Back.MultiplyScalar(size)
+
+	positions := math32.NewArrayF32(vertexCount*3, vertexCount*3)
+	positions.AppendVector3(
+		&zero, up,
+		&zero, right,
+		&zero, back,
 	)
-	colors := math32.NewArrayF32(0, 18)
-	colors.Append(
-		1, 0, 0, 1, 0.6, 0,
-		0, 1, 0, 0.6, 1, 0,
-		0, 0, 1, 0, 0.6, 1,
+
+	colors := math32.NewArrayF32(vertexCount*3, vertexCount*3)
+	colors.AppendColor(
+		&math32.Red, &math32.Red,
+		&math32.Green, &math32.Green,
+		&math32.Blue, &math32.Blue,
 	)
 	geom.AddVBO(gls.NewVBO().AddAttrib("VertexPosition", 3).SetBuffer(positions))
 	geom.AddVBO(gls.NewVBO().AddAttrib("VertexColor", 3).SetBuffer(colors))
 
 	// Creates line material
-	mat := material.NewBasic()
-	mat.SetLineWidth(2.0)
+	mat := material.NewScreenSpaceLine()
 
 	// Initialize lines with the specified geometry and material
 	axis.Lines.Init(geom, mat)

--- a/gui/chart.go
+++ b/gui/chart.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	shader.AddShader("shaderChartVertex", shaderChartVertex)
 	shader.AddShader("shaderChartFrag", shaderChartFrag)
-	shader.AddProgram("shaderChart", "shaderChartVertex", "shaderChartFrag")
+	shader.AddProgram("shaderChart", "shaderChartVertex", "shaderChartFrag", "")
 }
 
 //

--- a/material/basic.go
+++ b/material/basic.go
@@ -4,8 +4,6 @@
 
 package material
 
-import ()
-
 type Basic struct {
 	Material // Embedded material
 }

--- a/material/screenspaceline.go
+++ b/material/screenspaceline.go
@@ -1,0 +1,50 @@
+// Copyright 2016 The G3N Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package material
+
+import (
+	"github.com/g3n/engine/gls"
+)
+
+type ScreenSpaceLine struct {
+	Material                    // Embedded material
+	thickness    *gls.Uniform1f // thickness properties
+	viewPortSize *gls.Uniform2f // view port size properties
+}
+
+func NewScreenSpaceLine() *ScreenSpaceLine {
+
+	m := new(ScreenSpaceLine)
+	m.Material.Init()
+	m.thickness = gls.NewUniform1f("thickness")
+	m.viewPortSize = gls.NewUniform2f("viewportSize")
+
+	m.SetShader("shaderScreenSpaceLine")
+	m.SetDepthTest(false)
+	m.SetSide(SideDouble)
+	m.SetThickness(4.0)
+
+	return m
+}
+
+// SetThickness sets the line thickness
+// The default is 4.0
+func (m *ScreenSpaceLine) SetThickness(thickness float32) {
+
+	m.thickness.Set(thickness)
+}
+
+// RenderSetup is called by the engine before drawing the object
+// which uses this material
+func (m *ScreenSpaceLine) RenderSetup(gs *gls.GLS) {
+
+	m.Material.RenderSetup(gs)
+
+	_, _, width, height := gs.GetViewport()
+	m.viewPortSize.Set(float32(width), float32(height))
+
+	m.thickness.Transfer(gs)
+	m.viewPortSize.Transfer(gs)
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -56,9 +56,9 @@ func (r *Renderer) AddShader(name, source string) error {
 	return r.shaman.AddShader(name, source)
 }
 
-func (r *Renderer) AddProgram(name, vertex, frag string) error {
+func (r *Renderer) AddProgram(name, vertex, frag, geom string) error {
 
-	return r.shaman.AddProgram(name, vertex, frag)
+	return r.shaman.AddProgram(name, vertex, frag, geom)
 }
 
 func (r *Renderer) Render(iscene core.INode, icam camera.ICamera) error {

--- a/renderer/shader/shaderBasic.go
+++ b/renderer/shader/shaderBasic.go
@@ -7,7 +7,7 @@ package shader
 func init() {
 	AddShader("shaderBasicVertex", shaderBasicVertex)
 	AddShader("shaderBasicFrag", shaderBasicFrag)
-	AddProgram("shaderBasic", "shaderBasicVertex", "shaderBasicFrag")
+	AddProgram("shaderBasic", "shaderBasicVertex", "shaderBasicFrag", "")
 }
 
 //

--- a/renderer/shader/shaderPanel.go
+++ b/renderer/shader/shaderPanel.go
@@ -7,7 +7,7 @@ package shader
 func init() {
 	AddShader("shaderPanelVertex", shaderPanelVertex)
 	AddShader("shaderPanelFrag", shaderPanelFrag)
-	AddProgram("shaderPanel", "shaderPanelVertex", "shaderPanelFrag")
+	AddProgram("shaderPanel", "shaderPanelVertex", "shaderPanelFrag", "")
 }
 
 //

--- a/renderer/shader/shaderPhong.go
+++ b/renderer/shader/shaderPhong.go
@@ -7,7 +7,7 @@ package shader
 func init() {
 	AddShader("shaderPhongVertex", shaderPhongVertex)
 	AddShader("shaderPhongFrag", shaderPhongFrag)
-	AddProgram("shaderPhong", "shaderPhongVertex", "shaderPhongFrag")
+	AddProgram("shaderPhong", "shaderPhongVertex", "shaderPhongFrag", "")
 }
 
 //

--- a/renderer/shader/shaderPoint.go
+++ b/renderer/shader/shaderPoint.go
@@ -7,7 +7,7 @@ package shader
 func init() {
 	AddShader("shaderPointVertex", shaderPointVertex)
 	AddShader("shaderPointFrag", shaderPointFrag)
-	AddProgram("shaderPoint", "shaderPointVertex", "shaderPointFrag")
+	AddProgram("shaderPoint", "shaderPointVertex", "shaderPointFrag", "")
 }
 
 //

--- a/renderer/shader/shaderScreenSpaceLine.go
+++ b/renderer/shader/shaderScreenSpaceLine.go
@@ -1,0 +1,103 @@
+// Copyright 2016 The G3N Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package shader
+
+func init() {
+	AddShader("shaderScreenSpaceLineVertex", shaderScreenSpaceLineVertex)
+	AddShader("shaderScreenSpaceLineFrag", shaderScreenSpaceLineFrag)
+	AddShader("shaderScreenSpaceLineGeometry", shaderScreenSpaceLineGeometry)
+
+	AddProgram("shaderScreenSpaceLine",
+		"shaderScreenSpaceLineVertex",
+		"shaderScreenSpaceLineFrag",
+		"shaderScreenSpaceLineGeometry")
+}
+
+// Vertex Shader template
+const shaderScreenSpaceLineVertex = `
+#version {{.Version}}
+
+{{template "attributes" .}}
+{{template "material" .}}
+
+// Model uniforms
+uniform mat4 MVP;
+uniform vec2 viewportSize;
+uniform float thickness;
+
+// Output for geometry shader
+out vec3 o_color;
+out vec2 o_viewportSize;
+out float o_thickness; 
+
+void main() {
+
+    o_color = VertexColor;
+    o_viewportSize = viewportSize;
+    o_thickness = thickness;
+    
+    gl_Position = MVP * vec4(VertexPosition, 1.0);
+}
+`
+
+// Geometry Shader template
+const shaderScreenSpaceLineGeometry = `
+#version {{.Version}}
+
+layout(lines) in;
+layout(triangle_strip, max_vertices = 4) out;
+
+in vec3  o_color[2];
+in vec2  o_viewportSize[2];
+in float o_thickness[2];
+
+out vec3 Color;
+
+void main() {
+
+    vec4 ndc0 = gl_in[0].gl_Position;
+    vec4 ndc1 = gl_in[1].gl_Position;
+
+		// calculate the line normal (A - B)
+    vec2 direction = normalize( ndc1.xy - ndc0.xy );
+    vec2 normal = vec2( -direction.y, direction.x );
+
+    vec2 viewportSize = o_viewportSize[0];
+    float thickness = o_thickness[0]; 
+
+		// extrude & correct aspect ratio
+    vec2 offset = ( thickness / viewportSize) * normal;
+
+    gl_Position = vec4(ndc0.xy + offset * ndc0.w, ndc0.z, ndc0.w);
+    Color = o_color[0];
+    EmitVertex();
+
+    gl_Position = vec4(ndc0.xy - offset * ndc0.w, ndc0.z, ndc0.w);
+    Color = o_color[0];
+    EmitVertex();
+
+    gl_Position = vec4(ndc1.xy + offset * ndc1.w, ndc1.z, ndc1.w);
+    Color = o_color[1];
+    EmitVertex();
+
+    gl_Position = vec4(ndc1.xy - offset * ndc1.w, ndc1.z, ndc1.w);
+    Color = o_color[1];
+    EmitVertex();
+
+    EndPrimitive();
+}
+`
+
+// Fragment Shader template
+const shaderScreenSpaceLineFrag = `
+#version {{.Version}}
+
+in vec3 Color;
+out vec4 FragColor;
+
+void main() {
+  FragColor = vec4(Color, 1.0);
+}
+`

--- a/renderer/shader/shaderStandard.go
+++ b/renderer/shader/shaderStandard.go
@@ -7,7 +7,7 @@ package shader
 func init() {
 	AddShader("shaderStandardVertex", shaderStandardVertex)
 	AddShader("shaderStandardFrag", shaderStandardFrag)
-	AddProgram("shaderStandard", "shaderStandardVertex", "shaderStandardFrag")
+	AddProgram("shaderStandard", "shaderStandardVertex", "shaderStandardFrag", "")
 }
 
 //

--- a/renderer/shader/shaders.go
+++ b/renderer/shader/shaders.go
@@ -4,11 +4,10 @@
 
 package shader
 
-import ()
-
 type ProgramInfo struct {
 	Vertex string // Vertex shader name
 	Frag   string // Fragment shader name
+	Geom   string // Geometry shader name
 }
 
 var chunks = map[string]string{}
@@ -40,7 +39,11 @@ func AddShader(name, source string) {
 	shaders[name] = source
 }
 
-func AddProgram(name, vertexName, fragName string) {
+// AddProgram add a set of shader programms
+func AddProgram(name, vertexName, fragName, geomName string) {
 
-	programs[name] = ProgramInfo{vertexName, fragName}
+	// consider making the shader program arguments a type
+	// to make the interface a bit nicer and support optional/nill shaders
+
+	programs[name] = ProgramInfo{vertexName, fragName, geomName}
 }


### PR DESCRIPTION
Hi, here is a PR that implements the `Axis Helper` using a geometry shader. This fixes the line width issue reported on different platforms and hardware.

Perhaps stating the obvious, the PR also adds support for Geometry shaders to the engine. 

On a side note, I would like to suggest a future refactoring of `shaders.AddProgram(name, vertex, frag, geom string)` to a version that accepts a `Type`. That way optional shaders are more intuitive. 