### PR TITLE
OSX fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ In all cases it is necessary to have a gcc compatible C compiler installed.
 * For Windows the necessary audio libraries sources and `dlls` are supplied but they need to be installed
   manually. Please see [Audio libraries for Windows](audio/windows) for details.
   We tested the Windows build using the [mingw-w64](https://mingw-w64.org) toolchain.
-* Currently not tested on OS X.
+* On OSX, you should install the development files of OpenAL and Vorbis. If
+  your are using [Homebrew](https://brew.sh/) as your package manager, run:
+  `brew install libvorbis openal-soft`
 
 G3N was only tested with Go1.7.4+
 

--- a/audio/al/al.go
+++ b/audio/al/al.go
@@ -7,10 +7,10 @@
 package al
 
 /*
-#cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/include/AL
+#cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/local/opt/openal-soft/include/AL -I/usr/include/AL
 #cgo linux    CFLAGS:  -DGO_LINUX   -I/usr/include/AL
 #cgo windows  CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/openal-soft-1.18.2/include/AL
-#cgo darwin   LDFLAGS: -lopenal
+#cgo darwin   LDFLAGS: -L/usr/local/opt/openal-soft/lib -lopenal
 #cgo linux    LDFLAGS: -lopenal
 #cgo windows  LDFLAGS: -L${SRCDIR}/../windows/bin -lOpenAL32
 

--- a/audio/ov/vorbisfile.go
+++ b/audio/ov/vorbisfile.go
@@ -6,10 +6,10 @@
 // The libvorbisfile C API reference is at: https://xiph.org/vorbis/doc/vorbisfile/reference.html
 package ov
 
-// #cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis
+// #cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis -I/usr/local/include/vorbis
 // #cgo linux    CFLAGS:  -DGO_LINUX   -I/usr/include/vorbis
 // #cgo windows  CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/libvorbis-1.3.5/include/vorbis -I${SRCDIR}/../windows/libogg-1.3.3/include
-// #cgo darwin   LDFLAGS: -lvorbisfile
+// #cgo darwin   LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbisfile
 // #cgo linux    LDFLAGS: -lvorbisfile
 // #cgo windows  LDFLAGS: -L${SRCDIR}/../windows/bin -llibvorbisfile
 // #include <stdlib.h>

--- a/audio/vorbis/vorbis.go
+++ b/audio/vorbis/vorbis.go
@@ -6,10 +6,10 @@
 // See API reference at: https://xiph.org/vorbis/doc/libvorbis/reference.html
 package vorbis
 
-// #cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis
+// #cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis -I/usr/local/include/vorbis
 // #cgo linux    CFLAGS:  -DGO_LINUX   -I/usr/include/vorbis
 // #cgo windows  CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/libvorbis-1.3.5/include/vorbis -I${SRCDIR}/../windows/libogg-1.3.3/include
-// #cgo darwin   LDFLAGS: -lvorbis
+// #cgo darwin   LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbis
 // #cgo linux    LDFLAGS: -lvorbis
 // #cgo windows  LDFLAGS: -L${SRCDIR}/../windows/bin -llibvorbis
 // #include "codec.h"

--- a/gls/glapi.c
+++ b/gls/glapi.c
@@ -152,8 +152,37 @@ void glapiCheckError(int check) {
 
 // Internal function to abort process when error
 static void panic(GLenum err, const char* fname) {
-
-	printf("\nGLAPI Error: %d calling: %s\n", err, fname);
+	const char *msg;
+	switch(err) {
+		case GL_NO_ERROR:
+			msg = "No error";
+			break;
+		case GL_INVALID_ENUM:
+			msg = "An unacceptable value is specified for an enumerated argument";
+			break;
+		case GL_INVALID_VALUE:
+			msg = "A numeric argument is out of range";
+			break;
+		case GL_INVALID_OPERATION:
+			msg = "The specified operation is not allowed in the current state";
+			break;
+		case GL_INVALID_FRAMEBUFFER_OPERATION:
+			msg = "The framebuffer object is not complete";
+			break;
+		case GL_OUT_OF_MEMORY:
+			msg = "There is not enough memory left to execute the command";
+			break;
+		case GL_STACK_UNDERFLOW:
+			msg = "An attempt has been made to perform an operation that would cause an internal stack to underflow";
+			break;
+		case GL_STACK_OVERFLOW:
+			msg = "An attempt has been made to perform an operation that would cause an internal stack to overflow";
+			break;
+		default:
+			msg = "Unexpected error";
+			break;
+	}
+	printf("\nGLAPI Error: %s (%d) calling: %s\n", msg, err, fname);
 	exit(1);
 }
 

--- a/gls/glapi2go/template.go
+++ b/gls/glapi2go/template.go
@@ -235,8 +235,37 @@ void glapiCheckError(int check) {
 
 // Internal function to abort process when error
 static void panic(GLenum err, const char* fname) {
-
-	printf("\nGLAPI Error: %d calling: %s\n", err, fname);
+	const char *msg;
+	switch(err) {
+		case GL_NO_ERROR:
+			msg = "No error";
+			break;
+		case GL_INVALID_ENUM:
+			msg = "An unacceptable value is specified for an enumerated argument";
+			break;
+		case GL_INVALID_VALUE:
+			msg = "A numeric argument is out of range";
+			break;
+		case GL_INVALID_OPERATION:
+			msg = "The specified operation is not allowed in the current state";
+			break;
+		case GL_INVALID_FRAMEBUFFER_OPERATION:
+			msg = "The framebuffer object is not complete";
+			break;
+		case GL_OUT_OF_MEMORY:
+			msg = "There is not enough memory left to execute the command";
+			break;
+		case GL_STACK_UNDERFLOW:
+			msg = "An attempt has been made to perform an operation that would cause an internal stack to underflow";
+			break;
+		case GL_STACK_OVERFLOW:
+			msg = "An attempt has been made to perform an operation that would cause an internal stack to overflow";
+			break;
+		default:
+			msg = "Unexpected error";
+			break;
+	}
+	printf("\nGLAPI Error: %s (%d) calling: %s\n", msg, err, fname);
 	exit(1);
 }
 

--- a/gls/gls.go
+++ b/gls/gls.go
@@ -27,7 +27,6 @@ type GLS struct {
 	viewportY           int32             // cached last set viewport y
 	viewportWidth       int32             // cached last set viewport width
 	viewportHeight      int32             // cached last set viewport height
-	lineWidth           float32           // cached last set line width
 	sideView            int               // cached last set triangle side view mode
 	frontFace           uint32            // cached last set glFrontFace value
 	depthFunc           uint32            // cached last set depth function
@@ -127,7 +126,6 @@ func (gs *GLS) CheckErrors() bool {
 // reset resets the internal state kept of the OpenGL
 func (gs *GLS) reset() {
 
-	gs.lineWidth = 0.0
 	gs.sideView = uintUndef
 	gs.frontFace = 0
 	gs.depthFunc = 0
@@ -475,15 +473,6 @@ func (gs *GLS) GetUniformLocation(program uint32, name string) int32 {
 func (gs *GLS) GetViewport() (x, y, width, height int32) {
 
 	return gs.viewportX, gs.viewportY, gs.viewportWidth, gs.viewportHeight
-}
-
-func (gs *GLS) LineWidth(width float32) {
-
-	if gs.lineWidth == width {
-		return
-	}
-	C.glLineWidth(C.GLfloat(width))
-	gs.lineWidth = width
 }
 
 func (gs *GLS) LinkProgram(program uint32) {

--- a/graphic/axis_helper.go
+++ b/graphic/axis_helper.go
@@ -39,7 +39,6 @@ func NewAxisHelper(size float32) *AxisHelper {
 
 	// Creates line material
 	mat := material.NewBasic()
-	mat.SetLineWidth(2.0)
 
 	// Initialize lines with the specified geometry and material
 	axis.Lines.Init(geom, mat)

--- a/graphic/grid_helper.go
+++ b/graphic/grid_helper.go
@@ -43,7 +43,6 @@ func NewGridHelper(size, step float32, color *math32.Color) *GridHelper {
 
 	// Creates material
 	mat := material.NewBasic()
-	mat.SetLineWidth(1.0)
 
 	// Initialize lines with the specified geometry and material
 	grid.Lines.Init(geom, mat)

--- a/graphic/normals_helper.go
+++ b/graphic/normals_helper.go
@@ -21,7 +21,7 @@ type NormalsHelper struct {
 
 // NewNormalsHelper creates, initializes and returns a pointer to Normals helper object.
 // This helper shows the normal vectors of the specified object.
-func NewNormalsHelper(ig IGraphic, size float32, color *math32.Color, lineWidth float32) *NormalsHelper {
+func NewNormalsHelper(ig IGraphic, size float32, color *math32.Color) *NormalsHelper {
 
 	// Creates new Normals helper
 	nh := new(NormalsHelper)
@@ -44,7 +44,6 @@ func NewNormalsHelper(ig IGraphic, size float32, color *math32.Color, lineWidth 
 
 	// Creates this helper material
 	mat := material.NewStandard(color)
-	mat.SetLineWidth(lineWidth)
 
 	// Initialize graphic
 	nh.Lines.Init(geom, mat)

--- a/gui/chart.go
+++ b/gui/chart.go
@@ -653,12 +653,6 @@ func (lg *Graph) SetData(data []float32) {
 	lg.updateData()
 }
 
-// SetLineWidth sets the graph line width
-func (lg *Graph) SetLineWidth(width float32) {
-
-	lg.mat.SetLineWidth(width)
-}
-
 // updateData regenerates the lines for the current data
 func (lg *Graph) updateData() {
 

--- a/material/material.go
+++ b/material/material.go
@@ -205,11 +205,6 @@ func (mat *Material) SetBlending(blending Blending) {
 	mat.blending = blending
 }
 
-func (mat *Material) SetLineWidth(width float32) {
-
-	mat.lineWidth = width
-}
-
 func (mat *Material) SetPolygonOffset(factor, units float32) {
 
 	mat.polyOffsetFactor = factor
@@ -247,9 +242,6 @@ func (mat *Material) RenderSetup(gs *gls.GLS) {
 
 	// Set polygon offset if requested
 	gs.PolygonOffset(mat.polyOffsetFactor, mat.polyOffsetUnits)
-
-	// Sets line width
-	gs.LineWidth(mat.lineWidth)
 
 	// Sets blending
 	switch mat.blending {


### PR DESCRIPTION
Hi,
Currently the engine is not working on MacOS. Installation (via go get) does not work out-of-the-box, even when the dependencies are installed via Homebrew (the package manager that I think is the most widely used in the dev community). Furthermore, some of the examples crash, due to a call to glLineWidth. glLineWidth has been almost-deprecated in OpenGL 3.3 (it still exists, but will only accept line widths in the range ]0, 1], and those are basically always mapped to a value of 1). See the [specification](https://www.khronos.org/registry/OpenGL/specs/gl/glspec33.core.pdf), page 111.
This PR updates the search paths for Vorbis and OpenAL so that they support default `brew install` locations, updates the README file for instructions about how to set it all up on MacOS, and removes any call to glLineWidth.
This effectively removes the SetLineWidth feature from Material, but this feature was not reliable beforehand anyways. I also have updated the g3nd demos accordingly, and will do a PR there as well.
I could also have removed the content of SetLineWidth but kept it, so that it removes the crash but fails silently, thus keeping backward compatibility, but I'm not sure this is the right thing to do since g3nd is still young. What do you think about this?
Best regards!