### PR TITLE
Expose SetInputMode, SetCursorPos and GetFramebufferSize from glfw

### DIFF
--- a/window/glfw.go
+++ b/window/glfw.go
@@ -344,10 +344,14 @@ func (w *glfwWindow) SetStandardCursor(cursor StandardCursor) {
 	}
 }
 
+// SetInputMode changes specified input to specified state
+// Reference: http://www.glfw.org/docs/latest/group__input.html#gaa92336e173da9c8834558b54ee80563b
 func (w *glfwWindow) SetInputMode(mode InputMode, state int) {
 	w.win.SetInputMode(glfw.InputMode(mode), state)
 }
 
+// SetCursorPos sets cursor position in window coordinates
+// Reference: http://www.glfw.org/docs/latest/group__input.html#ga04b03af936d906ca123c8f4ee08b39e7
 func (w *glfwWindow) SetCursorPos(xpos, ypos float64) {
 	w.win.SetCursorPos(xpos, ypos)
 }

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -278,8 +278,12 @@ func (w *glfwWindow) SwapBuffers() {
 
 // Size returns this window size in screen coordinates
 func (w *glfwWindow) Size() (width int, height int) {
-
 	return w.win.GetSize()
+}
+
+// FramebufferSize returns framebuffer size of this window
+func (w *glfwWindow) FramebufferSize() (width int, height int) {
+	return w.win.GetFramebufferSize()
 }
 
 // SetSize sets the size, in screen coordinates, of the client area of this window

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -349,11 +349,13 @@ func (w *glfwWindow) SetStandardCursor(cursor StandardCursor) {
 // SetInputMode changes specified input to specified state
 // Reference: http://www.glfw.org/docs/latest/group__input.html#gaa92336e173da9c8834558b54ee80563b
 func (w *glfwWindow) SetInputMode(mode InputMode, state int) {
+
 	w.win.SetInputMode(glfw.InputMode(mode), state)
 }
 
 // SetCursorPos sets cursor position in window coordinates
 // Reference: http://www.glfw.org/docs/latest/group__input.html#ga04b03af936d906ca123c8f4ee08b39e7
 func (w *glfwWindow) SetCursorPos(xpos, ypos float64) {
+
 	w.win.SetCursorPos(xpos, ypos)
 }

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -278,11 +278,13 @@ func (w *glfwWindow) SwapBuffers() {
 
 // Size returns this window size in screen coordinates
 func (w *glfwWindow) Size() (width int, height int) {
+
 	return w.win.GetSize()
 }
 
 // FramebufferSize returns framebuffer size of this window
 func (w *glfwWindow) FramebufferSize() (width int, height int) {
+
 	return w.win.GetFramebufferSize()
 }
 

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -339,3 +339,11 @@ func (w *glfwWindow) SetStandardCursor(cursor StandardCursor) {
 		panic("Invalid cursor")
 	}
 }
+
+func (w *glfwWindow) SetInputMode(mode InputMode, state int) {
+	w.win.SetInputMode(glfw.InputMode(mode), state)
+}
+
+func (w *glfwWindow) SetCursorPos(xpos, ypos float64) {
+	w.win.SetCursorPos(xpos, ypos)
+}

--- a/window/window.go
+++ b/window/window.go
@@ -24,6 +24,7 @@ type IWindowManager interface {
 type IWindow interface {
 	core.IDispatcher
 	MakeContextCurrent()
+	FramebufferSize() (width int, height int)
 	Size() (width int, height int)
 	SetSize(width int, height int)
 	Pos() (xpos, ypos int)

--- a/window/window.go
+++ b/window/window.go
@@ -31,7 +31,7 @@ type IWindow interface {
 	SetPos(xpos, ypos int)
 	SetTitle(title string)
 	SetStandardCursor(cursor StandardCursor)
-	SetInputMode(InputMode, int)
+	SetInputMode(mode InputMode, state int)
 	SetCursorPos(xpos, ypos float64)
 	ShouldClose() bool
 	SetShouldClose(bool)

--- a/window/window.go
+++ b/window/window.go
@@ -30,6 +30,8 @@ type IWindow interface {
 	SetPos(xpos, ypos int)
 	SetTitle(title string)
 	SetStandardCursor(cursor StandardCursor)
+	SetInputMode(InputMode, int)
+	SetCursorPos(xpos, ypos float64)
 	ShouldClose() bool
 	SetShouldClose(bool)
 	FullScreen() bool


### PR DESCRIPTION
1. To properly support HiDPI screens, one should use framebuffer's height and width for viewport. g3nd and gokoban may be updated separately. Note that for cursor position window's height and width should be used.

2. SetInputMode with `DISABLED` cursor type may be used for first person camera (as per [glfw docs](http://www.glfw.org/docs/latest/group__input.html#gaa92336e173da9c8834558b54ee80563b)).
