### PR TITLE
Fix SetIndices() not marking indices as updated

### DIFF
--- a/geometry/geometry.go
+++ b/geometry/geometry.go
@@ -126,6 +126,7 @@ func (g *Geometry) GroupAt(idx int) *Group {
 func (g *Geometry) SetIndices(indices math32.ArrayU32) {
 
 	g.indices = indices
+	g.updateIndices = true
 	g.boundingBoxValid = false
 	g.boundingSphereValid = false
 }


### PR DESCRIPTION
Caused geometry to break when changing vertex buffer size.