### PR TITLE
Fix Application to use framebuffer size

### DIFF
--- a/util/application/application.go
+++ b/util/application/application.go
@@ -547,16 +547,15 @@ func (app *Application) Quit() {
 
 // OnWindowResize is default handler for window resize events.
 func (app *Application) OnWindowResize() {
-
-	// Get window size and sets the viewport to the same size
-	width, height := app.win.Size()
+	// Get framebuffer size and sets the viewport accordingly
+	width, height := app.win.FramebufferSize()
 	app.gl.Viewport(0, 0, int32(width), int32(height))
 
 	// Sets perspective camera aspect ratio
 	aspect := float32(width) / float32(height)
 	app.camPersp.SetAspect(aspect)
 
-	// Sets the GUI root panel size to the size of the screen
+	// Sets the GUI root panel size to the size of the framebuffer
 	if app.guiroot != nil {
 		app.guiroot.SetSize(float32(width), float32(height))
 	}


### PR DESCRIPTION
This fixes issues I described in this [issue](https://github.com/g3n/g3nd/issues/7#issuecomment-388544328).

However, GUI should somehow be adjusted because it's too small on HiDPI screens:
![image](https://storage.jumpshare.com/preview/DfIBCs0ZFvn7y0mQ5WzVNs-JXQJwS1P2AoLI1N4DDmLbYEkWFIQtW3qNJiekdVwy8DhMNQ5ZG9onjM6tEUi2WN0Iq-_ZMIwlJNqsu6s4bO0F1kR3dMUjedqC16uBUu85)

And the cursor hits incorrect. But think it's another issue and should be fixed on the GUI package separately. On non-HiDPI screens it works correctly.