### PR TITLE
Added method: Window

### DIFF
--- a/window/glfw.go
+++ b/window/glfw.go
@@ -75,6 +75,12 @@ func Glfw() (IWindowManager, error) {
 	return manager, nil
 }
 
+// Window returns the window pointer
+func (m *glfwManager) Window() interface{} {
+
+	return m.win
+}
+
 // ScreenResolution returns the screen resolution
 func (m *glfwManager) ScreenResolution(p interface{}) (width, height int) {
 

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -75,12 +75,6 @@ func Glfw() (IWindowManager, error) {
 	return manager, nil
 }
 
-// Window returns the window pointer
-func (m *glfwManager) Window() interface{} {
-
-	return m.win
-}
-
 // ScreenResolution returns the screen resolution
 func (m *glfwManager) ScreenResolution(p interface{}) (width, height int) {
 
@@ -237,6 +231,12 @@ func (m *glfwManager) CreateWindow(width, height int, title string, fullscreen b
 		w.SetFullScreen(true)
 	}
 	return w, nil
+}
+
+// Window returns the window pointer and satisfies the IWindow interface
+func (m *glfwWindow) Window() interface{} {
+
+	return m.win
 }
 
 // MakeContextCurrent makes the OpenGL context of this window current on the calling thread


### PR DESCRIPTION
`Window` returns the window pointer so that other OpenGL libraries can be used alongside g3n