### PR TITLE
Make SelectPos behave correctly

### DIFF
--- a/gui/dropdown.go
+++ b/gui/dropdown.go
@@ -128,8 +128,9 @@ func (dd *DropDown) SetSelected(item *ImageLabel) {
 
 // SelectPos selects the item at the specified position
 func (dd *DropDown) SelectPos(pos int) {
-
+    dd.list.SetSelected(dd.selItem, false)
 	dd.list.SelectPos(pos, true)
+    dd.Dispatch(OnChange, nil)
 }
 
 // onKeyEvent is called when key event is received when this dropdown has the key focus.
@@ -225,12 +226,16 @@ func (dd *DropDown) onListMouse(evname string, ev interface{}) {
 // copySelected copy to the dropdown panel the selected item
 // from the list.
 func (dd *DropDown) copySelected() {
-
-	dd.selItem = dd.list.Selected()[0].(*ImageLabel)
-	dd.litem.CopyFields(dd.selItem)
-	dd.litem.SetWidth(dd.selItem.Width())
-	dd.recalc()
-	dd.Dispatch(OnChange, nil)
+    selected := dd.list.Selected()
+    if len(selected) > 0 {
+        dd.selItem = selected[0].(*ImageLabel)
+        dd.litem.CopyFields(dd.selItem)
+        dd.litem.SetWidth(dd.selItem.Width())
+        dd.recalc()
+        dd.Dispatch(OnChange, nil)
+    } else {
+        return
+    }
 }
 
 // onListChangeEvent is called when an item in the list is selected


### PR DESCRIPTION
When new item is selected through SelectPos it does not unselect previously selected items, resulting in multiple selected items when items are added to the dropdown through DropDown Add function. This makes it so that it SelectPos() has similar behavior to SetSelected(). 

**Problem illustrated here:**

![0hgkykkeat](https://user-images.githubusercontent.com/8211563/43865366-487de526-9b17-11e8-8b4e-4b1ee1081b45.gif)

**Solution here:**

![ayyewletxn](https://user-images.githubusercontent.com/8211563/43865746-421f4aac-9b18-11e8-86e0-8e1b50cbba3b.gif)