### PR TITLE
Fix raycasts: the least obvious way

### DIFF
--- a/core/node.go
+++ b/core/node.go
@@ -632,6 +632,7 @@ func (n *Node) SetMatrix(m *math32.Matrix4) {
 
 	n.matrix = *m
 	n.matrix.Decompose(&n.position, &n.quaternion, &n.scale)
+	n.changed = true
 }
 
 // Matrix returns a copy of the local transformation matrix.


### PR DESCRIPTION
Apparently, [this change](https://github.com/g3n/engine/commit/8ff00c41085ce75e688b93d2ad87c06440ad4dcd#diff-23fd9a32a9a874814a4f6b8bfb16730fL576) broke raycasts (in my use case): they [almost always](https://en.wikipedia.org/wiki/Almost_everywhere) have incorrect `Index` after 8ff00c41.

I don't think I understand why exactly that happened, but setting 'changed' to true after changing node's matrix seems legit (and it fixes the issue)
