### PR TITLE
Fix incorrect index calculation in Mesh.Raycast()

### DIFF
--- a/graphic/mesh.go
+++ b/graphic/mesh.go
@@ -154,7 +154,7 @@ func (m *Mesh) Raycast(rc *core.Raycaster, intersects *[]core.Intersect) {
 			intersect.Index = uint32(i)
 			*intersects = append(*intersects, *intersect)
 		}
-		i++
+		i += 3
 		return false
 	})
 }


### PR DESCRIPTION
This fixes #78.

After doing some [git twiddling](https://gist.github.com/exploser/f05fe165c605fd169a15abb3f616f4d4), I found that b3566fb was the original cause of this problem.

If you take a look at [this line](https://github.com/g3n/engine/commit/b3566fbac00e93749a072d48d09ef861d76704e2#diff-930d0adccf9b94a9f70e2d5934bf55f9L159) and compare it to [the new one](https://github.com/g3n/engine/commit/b3566fbac00e93749a072d48d09ef861d76704e2#diff-930d0adccf9b94a9f70e2d5934bf55f9R157), you might notice that in the updated version indices are incremented by 1 instead of 3, which caused the initial bug.