### PR TITLE
Create button_destructive.go

### DIFF
--- a/gui/button_destructive.go
+++ b/gui/button_destructive.go
@@ -1,0 +1,40 @@
+// Copyright 2016 The G3N Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gui
+
+//import (
+//	"github.com/g3n/engine/window"
+//)
+
+/***************************************
+
+ ButtonDestructive Panel
+ +-------------------------------+
+ |  Image/Icon      Label        |
+ |  +----------+   +----------+  |
+ |  |          |   |          |  |
+ |  |          |   |          |  |
+ |  +----------+   +----------+  |
+ +-------------------------------+
+
+****************************************/
+
+// ButtonDestructive represents a destructive button GUI element
+type ButtonDestructive struct {
+	Button                          // Embedded Button
+	styles *ButtonDestructiveStyles // pointer to current destructive button styles
+}
+
+// ButtonDestructiveStyle contains the styling of a ButtonDestructive
+type ButtonDestructiveStyle ButtonStyle
+
+// ButtonDestructiveStyles contains one ButtonDestructiveStyle for each possible button state
+type ButtonDestructiveStyles struct {
+	Normal       ButtonDestructiveStyle
+	Over         ButtonDestructiveStyle
+	PressedOnce  ButtonDestructiveStyle
+	PressedTwice ButtonDestructiveStyle
+	Disabled     ButtonDestructiveStyle
+}


### PR DESCRIPTION
I don't know how to modify two files in a single PR so I'm having to submit this in parts so that g3n will continue to build successfully after each merge.  It will be a series of 3 (I think) pull requests that you can merge in order and it should compile after each PR.  This is the first in the series.

This series of PRs introduces a new type, ButtonDestructive, which is extremely similar to Button (and uses it internally), but requires two clicks to activate.  After the first click, the style and optionally the label text change to indicate that another click is necessary.  If the mouse cursor leaves the widget then it is reset.  If a second click happens then the associated (usually destructive, hence the name) subscribed action is called.
