### PR TITLE
Fix blender v2.79 collada exports loading

### DIFF
--- a/loader/collada/library_geometries.go
+++ b/loader/collada/library_geometries.go
@@ -327,7 +327,7 @@ func (d *Decoder) decMesh(start xml.StartElement, geom *Geometry) error {
 			continue
 		}
 		// Decodes polylist
-		if child.Name.Local == "polylist" {
+		if child.Name.Local == "polylist" || child.Name.Local == "triangles" {
 			err = d.decPolylist(child, mesh)
 			if err != nil {
 				return err
@@ -408,6 +408,15 @@ func (d *Decoder) decPolylist(start xml.StartElement, mesh *Mesh) error {
 	pl.Count, _ = strconv.Atoi(findAttrib(start, "count").Value)
 	pl.Material = findAttrib(start, "material").Value
 	mesh.PrimitiveElements = append(mesh.PrimitiveElements, pl)
+
+	// blender exporter now (since v2.79) exports meshes as <Triangles> when all contained polygons are tris
+	// https://developer.blender.org/rBc9b95c28f64e9d7421b00cbf8ed4ecddd6471ae5
+	if start.Name.Local == "triangles" {
+		pl.Vcount = make([]int, pl.Count)
+		for i := range pl.Vcount {
+			pl.Vcount[i] = 3
+		}
+	}
 
 	for {
 		// Get next child


### PR DESCRIPTION
blender exporter now (since v2.79) exports meshes as `<Triangles>` when all contained polygons are tris
https://developer.blender.org/rBc9b95c28f64e9d7421b00cbf8ed4ecddd6471ae5

Test: Export `g3nd@master/data% blender blender/scene.blend` with blender version 2.79+

```
 g3n/g3nd@master% diff -u data/collada/scene.dae data/blender/scene.dae |grep -A 5 polylist|head -n 10
-        <polylist material="PlaneGreen-material" count="2">
+        <triangles material="PlaneGreen-material" count="2">
           <input semantic="VERTEX" source="#Plane-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane-mesh-normals" offset="1"/>
-          <vcount>3 3 </vcount>
           <p>1 0 2 0 0 0 1 0 3 0 2 0</p>
-        </polylist>
+        </triangles>
       </mesh>
     </geometry
```

Why `d.decTriangles()` or `newMeshTriangles(m, pet)` wasn't added:
Didn't bother implementing since its exactly the same code as `newMeshPolylist(m, m.PrimitiveElements)` except the `vcount` part.