### PR TITLE
fix osx GUI mouse window drags and resizes

### DIFF
--- a/gui/root.go
+++ b/gui/root.go
@@ -273,11 +273,6 @@ func (r *Root) onCursor(evname string, ev interface{}) {
 // which contain the specified screen position
 func (r *Root) sendPanels(x, y float32, evname string, ev interface{}) {
 
-	// Apply scale of window (for HiDPI support)
-	sX64, sY64 := r.Window().Scale()
-	x /= float32(sX64)
-	y /= float32(sY64)
-
 	// If there is panel with MouseFocus send only to this panel
 	if r.mouseFocus != nil {
 		// Checks modal panel

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -244,8 +244,8 @@ func (m *glfwManager) CreateWindow(width, height int, title string, fullscreen b
 		w.mouseEv.Button = MouseButton(button)
 		w.mouseEv.Action = Action(action)
 		w.mouseEv.Mods = ModifierKey(mods)
-		w.mouseEv.Xpos = float32(xpos * w.scaleX)
-		w.mouseEv.Ypos = float32(ypos * w.scaleY)
+		w.mouseEv.Xpos = float32(xpos)
+		w.mouseEv.Ypos = float32(ypos)
 
 		if action == glfw.Press {
 			w.Dispatch(OnMouseDown, &w.mouseEv)
@@ -282,8 +282,8 @@ func (m *glfwManager) CreateWindow(width, height int, title string, fullscreen b
 	win.SetCursorPosCallback(func(x *glfw.Window, xpos float64, ypos float64) {
 
 		w.cursorEv.W = w
-		w.cursorEv.Xpos = float32(xpos * w.scaleX)
-		w.cursorEv.Ypos = float32(ypos * w.scaleY)
+		w.cursorEv.Xpos = float32(xpos)
+		w.cursorEv.Ypos = float32(ypos)
 		w.Dispatch(OnCursor, &w.cursorEv)
 	})
 


### PR DESCRIPTION
On osx with retina when you dragged a gui window it would move a 2x the rate of the mouse cursor, and the horiz and vert cursor icons to resize the window would appear offset 50% to the right of the window. tested on windows, osx and linux for my app and gokoban and they appear to work as expected. 

I think what was happening was that on windows and linux the framebuffer and screen size were the same so the scaling factor always defaults to 1.0 and was a nop for these scaling operations in the commit here, however on osx with retina the framebuffer/screen scale factor was 2.0 so it only showed up then. That's my understanding at least.