### PR TITLE
only parse flags if flags are enabled in an application

### DIFF
--- a/util/application/application.go
+++ b/util/application/application.go
@@ -114,8 +114,8 @@ func Create(ops Options) (*Application, error) {
 		app.noglErrors = flag.Bool("noglerrors", false, "Do not check OpenGL errors at each call (may increase FPS)")
 		app.cpuProfile = flag.String("cpuprofile", "", "Activate cpu profiling writing profile to the specified file")
 		app.execTrace = flag.String("exectrace", "", "Activate execution tracer writing data to the specified file")
+		flag.Parse()
 	}
-	flag.Parse()
 
 	// Creates application logger
 	app.log = logger.New(ops.LogPrefix, nil)


### PR DESCRIPTION
the application was always parsing the command line args even if it wasn't configured to. this lead to unexpected behavior that caused it to parse command line args not intended for it, and would fail to start up with an error like the following:

```
./myapp -c foo
flag provided but not defined: -c
```