### PR TITLE
Issue 29: default material for OBJ decode

### DIFF
--- a/loader/obj/obj.go
+++ b/loader/obj/obj.go
@@ -102,16 +102,6 @@ func Decode(objpath string, mtlpath string) (*Decoder, error) {
 	}
 	defer fobj.Close()
 
-	// TODO: remove
-	// If path of material file not supplied,
-	// try to use the base name of the obj file
-	// if len(mtlpath) == 0 {
-	// 	dir, objfile := filepath.Split(objpath)
-	// 	ext := filepath.Ext(objfile)
-	// 	mtlpath = dir + objfile[:len(objfile)-len(ext)] + ".mtl"
-	// }
-
-	fmt.Println("USING TEST VERSION") // TODO: remove
 	// Opens mtl file
 	// if mtlpath=="", then os.Open() will produce an error,
 	// causing fmtl to be nil
@@ -179,13 +169,10 @@ func DecodeReader(objreader, mtlreader io.Reader) (*Decoder, error) {
 				mtllibPath = filepath.Join(objdir, dec.Matlib)
 				dec.mtlDir = objdir // NOTE (quillaja): should this be set?
 			}
-			fmt.Println("mtllib:", mtllibPath) // TODO: remove
 			mtlf, errMTL := os.Open(mtllibPath)
 			defer mtlf.Close()
 			if errMTL == nil {
-				fmt.Println("attempting to parse", mtllibPath)  // TODO: remove
-				err = dec.parse(mtlf, dec.parseMtlLine)         // will set err to nil if successful
-				fmt.Println("error while parsing mtllib:", err) // TODO: remove
+				err = dec.parse(mtlf, dec.parseMtlLine) // will set err to nil if successful
 			}
 		}
 
@@ -198,13 +185,10 @@ func DecodeReader(objreader, mtlreader io.Reader) (*Decoder, error) {
 				mtlpath = objdir + ".mtl"
 				dec.mtlDir = objdir // NOTE (quillaja): should this be set?
 			}
-			fmt.Println("mtl file:", mtlpath) // TODO: remove
 			mtlf, errMTL := os.Open(mtlpath)
 			defer mtlf.Close()
 			if errMTL == nil {
-				fmt.Println("attempting to parse", mtlpath)        // TODO: remove
-				err = dec.parse(mtlf, dec.parseMtlLine)            // will set err to nil if successful
-				fmt.Println("error while parsing <obj>.mtl:", err) // TODO: remove
+				err = dec.parse(mtlf, dec.parseMtlLine) // will set err to nil if successful
 				if err == nil {
 					// log a warning
 					msg := fmt.Sprintf("using material file %s", mtlpath)
@@ -220,7 +204,6 @@ func DecodeReader(objreader, mtlreader io.Reader) (*Decoder, error) {
 			for key := range dec.Materials {
 				dec.Materials[key] = defaultMat
 			}
-			fmt.Println("logged warning for last ditch effort") // TODO: remove
 			// NOTE (quillaja): could be an error of some custom type. But people
 			// tend to ignore errors and pass them up the call stack instead
 			// of handling them... so all this work would probably be wasted.

--- a/loader/obj/obj.go
+++ b/loader/obj/obj.go
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package obj
+// Package obj is used to parse the Wavefront OBJ file format (*.obj), including
+// associated materials (*.mtl). Not all features of the OBJ format are
+// supported. Basic format info: https://en.wikipedia.org/wiki/Wavefront_.obj_file
 package obj
 
 import (
@@ -71,6 +73,7 @@ type Material struct {
 	MapKd      string       // Texture file linked to diffuse color
 }
 
+// Light gray default material used as when other materials cannot be loaded.
 var defaultMat = &Material{
 	Diffuse:   math32.Color{R: 0.7, G: 0.7, B: 0.7},
 	Ambient:   math32.Color{R: 0.7, G: 0.7, B: 0.7},
@@ -87,7 +90,9 @@ const (
 )
 
 // Decode decodes the specified obj and mtl files returning a decoder
-// object and an error.
+// object and an error. Passing an empty string (or otherwise invalid path)
+// to mtlpath will cause the decoder to check the 'mtllib' file in the OBJ if
+// present, and fall back to a default material as a last resort.
 func Decode(objpath string, mtlpath string) (*Decoder, error) {
 
 	// Opens obj file
@@ -97,6 +102,7 @@ func Decode(objpath string, mtlpath string) (*Decoder, error) {
 	}
 	defer fobj.Close()
 
+	// TODO: remove
 	// If path of material file not supplied,
 	// try to use the base name of the obj file
 	// if len(mtlpath) == 0 {
@@ -105,7 +111,7 @@ func Decode(objpath string, mtlpath string) (*Decoder, error) {
 	// 	mtlpath = dir + objfile[:len(objfile)-len(ext)] + ".mtl"
 	// }
 
-	fmt.Println("USING TEST VERSION")
+	fmt.Println("USING TEST VERSION") // TODO: remove
 	// Opens mtl file
 	// if mtlpath=="", then os.Open() will produce an error,
 	// causing fmtl to be nil
@@ -113,7 +119,8 @@ func Decode(objpath string, mtlpath string) (*Decoder, error) {
 	defer fmtl.Close() // will produce (ignored) err if fmtl==nil
 
 	// if fmtl==nil, the io.Reader in DecodeReader() will be (T=*os.File, V=nil)
-	// which is NOT equal to plain nil or (io.Reader, nil)
+	// which is NOT equal to plain nil or (io.Reader, nil) but will produce
+	// the desired result of passing nil to DecodeReader() per it's func comment.
 	dec, err := DecodeReader(fobj, fmtl)
 	if err != nil {
 		return nil, err
@@ -146,8 +153,6 @@ func DecodeReader(objreader, mtlreader io.Reader) (*Decoder, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// fmt.Printf("before dec.parse(mtlreader), mtlreader=<%#v>\n", mtlreader)
 
 	// Parses mtl lines
 	// 1) try passed in mtlreader,
@@ -188,7 +193,7 @@ func DecodeReader(objreader, mtlreader io.Reader) (*Decoder, error) {
 				dec.Materials[key] = defaultMat
 			}
 			fmt.Println("logged warning for last ditch effort")
-			// NOTE (quillaja): could be an error instead of some custom type.
+			// NOTE (quillaja): could be an error of some custom type.
 			dec.appendWarn(mtlType, "unable to parse a mtl file for obj. using default material instead.")
 		}
 	}
@@ -221,12 +226,8 @@ func (dec *Decoder) NewMesh(obj *Object) (*graphic.Mesh, error) {
 		return nil, err
 	}
 
-	// defaultMaterial := material.NewPhong(math32.NewColor("gray"))
-
 	// Single material
 	if geom.GroupCount() == 1 {
-		// fmt.Println("single group geom")
-
 		// get Material info from mtl file and ensure it's valid.
 		// substitute default material if it is not.
 		var matDesc *Material
@@ -258,7 +259,6 @@ func (dec *Decoder) NewMesh(obj *Object) (*graphic.Mesh, error) {
 	}
 
 	// Multi material
-	// fmt.Println("multi group geom")
 	mesh := graphic.NewMesh(geom, nil)
 	for idx := 0; idx < geom.GroupCount(); idx++ {
 		group := geom.GroupAt(idx)
@@ -463,7 +463,7 @@ func (dec *Decoder) parseObjLine(line string) error {
 func (dec *Decoder) parseMatlib(fields []string) error {
 
 	if len(fields) < 1 {
-		return errors.New("Object line (o) with less than 2 fields")
+		return errors.New("Material library (mtllib) with no fields")
 	}
 	dec.Matlib = fields[0]
 	return nil
@@ -474,7 +474,7 @@ func (dec *Decoder) parseMatlib(fields []string) error {
 func (dec *Decoder) parseObject(fields []string) error {
 
 	if len(fields) < 1 {
-		return errors.New("Object line (o) with less than 2 fields")
+		return errors.New("Object line (o) with no fields")
 	}
 	var ob Object
 	ob.Name = fields[0]
@@ -555,7 +555,7 @@ func (dec *Decoder) parseFace(fields []string) error {
 	if dec.matCurrent != nil {
 		face.Material = dec.matCurrent.Name
 	} else {
-		// TODO (Ben): do something better than spamming warnings for each line
+		// TODO (quillaja): do something better than spamming warnings for each line
 		// dec.appendWarn(objType, "No material defined")
 		face.Material = "internal default" // causes error on in NewGeom() if ""
 		// dec.matCurrent = defaultMat


### PR DESCRIPTION
Per discussion on issue #29, here are changes to handle material loading with increased protection from failure. Most of the changes are in `DecodeReader()`, some in `Decode()` and `NewMesh()`.

Essentially, what now happens is that Decode() will try to open the material file path specified, passing the io.Reader to DecodeReader(). An error opening the file in Decode(), will give an invalid (nil) io.Reader to DecodeReader(). The user can use DeodeReader() directly as well. 

If DecodeReader() will attempt to use the io.Reader to source materials. If the io.Reader is invalid due to an error or on purpose (user passed nil), DecodeReader() will attempt to load materials in the following order:
 1. from the `mtllib` line in the OBJ file, if present. (this is an optional part of the OBJ spec)
 2. from a file named the same as the OBJ file with a `.mtl` extension (eg gopher.obj -> gopher.mtl) in the same directory as the OBJ.
 3. all materials specified in the OBJ (via `usemtl`) are replaced with a default gray material defined as the package variable `defaultMat`.

The changes in NewMesh() amount to protecting from array-out-of-bounds and nil-pointer errors that result from no definition being found for materials specified in the `usemtl` lines. `usemtl` is also optional in the OBJ spec, so even if valid material definitions are available (via one of the methods described above), an geometry may not specify a material. This would cause the entire OBJ decode to fail previously; now it substitutes the gray `defaultMat`.

I commented code liberally, and added documentation to methods where appropriate.

Attached is the gopher model from the g3n demos with normal materials and with the default material.
![gopher_with_materials](https://user-images.githubusercontent.com/17558269/54199170-7bcecb80-4485-11e9-96f5-5d1c3203ad82.png)
![gopher_default_material](https://user-images.githubusercontent.com/17558269/54199169-7bcecb80-4485-11e9-9a54-3d3c908827e4.png)
