### PR TITLE
Added ReadPixels to read current image

### DIFF
--- a/gls/gls.go
+++ b/gls/gls.go
@@ -339,6 +339,18 @@ func (gs *GLS) DeleteProgram(program uint32) {
 	C.glDeleteProgram(C.GLuint(program))
 }
 
+// ReadPixels returns the current rendererd image.
+// x, y: specify the window coordinates of the first pixel that is read from the frame buffer.
+// width, height: specify the dimensions of the pixel rectangle.
+// format specifies the format of the pixel data.
+// format_type specifies the data type of the pixel data.
+// more information: http://docs.gl/es3/glReadPixels
+func (gs *GLS) ReadPixels(x, y, width, height int, format, format_type int) []byte {
+	size := uint32((width - x) * (height - y) * 4)
+	C.glReadPixels(C.GLint(x), C.GLint(y), C.GLint(height), C.GLint(width), C.GLenum(format), C.GLenum(format_type), unsafe.Pointer(gs.gobufSize(size)))
+	return gs.gobuf[:size]
+}
+
 // DeleteTextures deletes n​textures named
 // by the elements of the provided array.
 func (gs *GLS) DeleteTextures(tex ...uint32) {


### PR DESCRIPTION
Hi, I'm building a server-side 3D viewer based on g3n. the server is streaming rendered images to webclients and listens for navigation events to update scenes. In order to capture the current rendered image I used the same approach as @rami-dabain in #105. It would be great to have such a method in the g3n engine.