### PR TITLE
Add WithFramebuffer and improve ReadPixels.

### DIFF
--- a/gls/gls-desktop.go
+++ b/gls/gls-desktop.go
@@ -13,9 +13,13 @@ package gls
 import "C"
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"unsafe"
+	"encoding/binary"
+
+	"github.com/g3n/engine/math32"
 )
 
 // GLS encapsulates the state of an OpenGL context and contains
@@ -342,16 +346,57 @@ func (gs *GLS) DeleteVertexArrays(vaos ...uint32) {
 	gs.stats.Vaos -= len(vaos)
 }
 
-// ReadPixels returns the current rendered image.
+// WithFramebuffer executes f inside a framebuffer context.
+func (gs *GLS) WithFramebuffer(f func()) {
+	fbo := C.GLuint(0)
+	rboColor := C.GLuint(0)
+	rboDepth := C.GLuint(0)
+
+	C.glGenFramebuffers(1, &fbo)
+	C.glGenRenderbuffers(1, &rboColor)
+	C.glGenRenderbuffers(1, &rboDepth)
+
+	C.glBindFramebuffer(FRAMEBUFFER, fbo)
+
+	// Color renderbuffer
+	C.glBindRenderbuffer(RENDERBUFFER, rboColor)
+	C.glRenderbufferStorage(RENDERBUFFER, RGBA32F, C.GLint(gs.viewportWidth), C.GLint(gs.viewportHeight))
+	C.glFramebufferRenderbuffer(DRAW_FRAMEBUFFER, COLOR_ATTACHMENT0, RENDERBUFFER, rboColor)
+
+	// Depth renderbuffer
+	C.glBindRenderbuffer(RENDERBUFFER, rboDepth)
+	C.glRenderbufferStorage(RENDERBUFFER, DEPTH_COMPONENT16, C.GLint(gs.viewportWidth), C.GLint(gs.viewportHeight))
+	C.glFramebufferRenderbuffer(DRAW_FRAMEBUFFER, DEPTH_ATTACHMENT, RENDERBUFFER, rboDepth)
+
+	C.glReadBuffer(COLOR_ATTACHMENT0)
+
+	f()
+
+	C.glDeleteFramebuffers(1, &fbo)
+	C.glDeleteRenderbuffers(1, &rboColor)
+	C.glDeleteRenderbuffers(1, &rboDepth)
+}
+
+// ReadPixels reads from the current rendered image or framebuffer.
 // x, y: specifies the window coordinates of the first pixel that is read from the frame buffer.
 // width, height: specifies the dimensions of the pixel rectangle.
-// format: specifies the format of the pixel data.
-// format_type: specifies the data type of the pixel data.
 // more information: http://docs.gl/gl3/glReadPixels
-func (gs *GLS) ReadPixels(x, y, width, height, format, formatType int) []byte {
-	size := uint32((width - x) * (height - y) * 4)
-	C.glReadPixels(C.GLint(x), C.GLint(y), C.GLsizei(width), C.GLsizei(height), C.GLenum(format), C.GLenum(formatType), unsafe.Pointer(gs.gobufSize(size)))
-	return gs.gobuf[:size]
+func (gs *GLS) ReadPixels(x, y, width, height int) [][]*math32.Color4 {
+	size := uint32(width * height * 4 * 4)
+	C.glReadPixels(C.GLint(x), C.GLint(int(gs.viewportHeight)-y), C.GLsizei(width), C.GLsizei(height), C.GLenum(RGBA), C.GLenum(FLOAT), unsafe.Pointer(gs.gobufSize(size)))
+	pixels := make([][]*math32.Color4, width)
+	for x := 0; x < width; x++ {
+		pixels[x] = make([]*math32.Color4, height)
+		for y := 0; y < height; y++ {
+			var r, g, b, a float32
+			binary.Read(bytes.NewBuffer(gs.gobuf[:size][y*16+x:y*16+x+4]), binary.LittleEndian, &r)
+			binary.Read(bytes.NewBuffer(gs.gobuf[:size][y*16+x+4:y*16+x+8]), binary.LittleEndian, &g)
+			binary.Read(bytes.NewBuffer(gs.gobuf[:size][y*16+x+8:y*16+x+12]), binary.LittleEndian, &b)
+			binary.Read(bytes.NewBuffer(gs.gobuf[:size][y*16+x+12:y*16+x+16]), binary.LittleEndian, &a)
+			pixels[x][y] = &math32.Color4{R: r, G: g, B: b, A: a}
+		}
+	}
+	return pixels
 }
 
 // DepthFunc specifies the function used to compare each incoming pixel


### PR DESCRIPTION
This is more of an RFC/work in progress. This would be one approach to https://github.com/g3n/engine/projects/2#card-2113773. You can see it in action at https://github.com/etherealmachine/novaterra/blob/f425986575b742d5a4f123f3da130cdabb16b908/main.go#L163 where I use it to swap in a shader to do color-based mouse picking. I'm also planning to do some computation on the GPU in shaders where this approach could be useful.

There are a few things that should probably be addressed before merging:

1. Is calling glGen{Frame,Render}buffers and glRenderbufferStorage and then destroying resources after performant? Or is pre-allocating everything better. If so, that means changing the alloc when the screen size changes.
2. Is the breaking change in ReadPixels ok? Honestly I'm not sure it's being used much, I can't find any examples and I think the size calculation is currently incorrect.
3. Is allocating color structs in ReadPixels ok? It makes the return value quite nice to work with, but a more compact format might be nice, or possibly a raw ReadPixels and a ReadPixelsArray that is slightly less performant.
4. What's the best way to figure out the byte order in ReadPixels (or a variant)?