### PR TITLE
Add support for compressed texture formats

### DIFF
--- a/gls/gls-desktop.go
+++ b/gls/gls-desktop.go
@@ -601,7 +601,7 @@ func (gs *GLS) TexImage2D(target uint32, level int32, iformat int32, width int32
 		ptr(data))
 }
 
-// CompressedTexImage2D specified a two-dimensional compressed texture image.
+// CompressedTexImage2D specifies a two-dimensional compressed texture image.
 func (gs *GLS) CompressedTexImage2D(target uint32, level uint32, iformat uint32, width int32, height int32, size int32, data interface{}) {
 
 	C.glCompressedTexImage2D(C.GLenum(target),

--- a/gls/gls-desktop.go
+++ b/gls/gls-desktop.go
@@ -601,6 +601,19 @@ func (gs *GLS) TexImage2D(target uint32, level int32, iformat int32, width int32
 		ptr(data))
 }
 
+// CompressedTexImage2D specified a two-dimensional compressed texture image.
+func (gs *GLS) CompressedTexImage2D(target uint32, level uint32, iformat uint32, width int32, height int32, size int32, data interface{}) {
+
+	C.glCompressedTexImage2D(C.GLenum(target),
+		C.GLint(level),
+		C.GLenum(iformat),
+		C.GLsizei(width),
+		C.GLsizei(height),
+		C.GLint(0),
+		C.GLsizei(size),
+		ptr(data))
+}
+
 // TexParameteri sets the specified texture parameter on the specified texture.
 func (gs *GLS) TexParameteri(target uint32, pname uint32, param int32) {
 

--- a/texture/texture2D.go
+++ b/texture/texture2D.go
@@ -109,6 +109,7 @@ func NewTexture2DFromData(width, height int, format int, formatType, iformat int
 	return t
 }
 
+// NewTexture2DFromCompressedData creates a new compressed texture from data
 func NewTexture2DFromCompressedData(width, height int, iformat int32, size int32, data interface{}) *Texture2D {
 
 	t := newTexture2D()

--- a/texture/texture2D.go
+++ b/texture/texture2D.go
@@ -113,7 +113,7 @@ func NewTexture2DFromData(width, height int, format int, formatType, iformat int
 func NewTexture2DFromCompressedData(width, height int, iformat int32, size int32, data interface{}) *Texture2D {
 
 	t := newTexture2D()
-	t.SetDataCompressed(width, height, iformat, size, data)
+	t.SetCompressedData(width, height, iformat, size, data)
 	return t
 }
 
@@ -193,8 +193,8 @@ func (t *Texture2D) SetData(width, height int, format int, formatType, iformat i
 	t.updateData = true
 }
 
-// SetDataCompressed sets the compressed texture data
-func (t *Texture2D) SetDataCompressed(width, height int, iformat int32, size int32, data interface{}) {
+// SetCompressedData sets the compressed texture data
+func (t *Texture2D) SetCompressedData(width, height int, iformat int32, size int32, data interface{}) {
 
 	t.width = int32(width)
 	t.height = int32(height)


### PR DESCRIPTION
Added support for compressed textures by calling into glCompressedTexImage2D through new functions in GLS and Texture2D for creating them.