### PR TITLE
Adding SetCursorPos and SetCursorMode to window

### DIFF
--- a/window/canvas.go
+++ b/window/canvas.go
@@ -599,8 +599,8 @@ func (w *WebGlCanvas) SetCursorMode(mode CursorMode) {
 }
 
 // SetCursorPos sets the cursor position in screen coordinates
-func (w *WebGlCanvas) SetCursorPos(x float64, y float64) {
-	w.Window.SetCursorPos(x, y)
+func (w *WebGlCanvas) SetCursorPos(x int, y int) {
+	w.Window.SetCursorPos(float64(x), float64(y))
 }
 
 // SetInputMode changes specified input to specified state

--- a/window/canvas.go
+++ b/window/canvas.go
@@ -593,6 +593,15 @@ func (w *WebGlCanvas) DisposeAllCustomCursors() {
 	// TODO
 }
 
+// SetCursorMode hides, disables, and returns the cursor back to normal depending on the mode provided
+func (w *WebGlCanvas) SetCursorMode(mode CursorMode) {
+	w.Window.SetInputMode(glfw.CursorMode, int(mode))
+}
+
+func (w *WebGlCanvas) SetCursorPos(x float64, y float64) {
+	w.Window.SetCursorPos(xpos, ypos)
+}
+
 // SetInputMode changes specified input to specified state
 //func (w *WebGlCanvas) SetInputMode(mode InputMode, state int) {
 //

--- a/window/canvas.go
+++ b/window/canvas.go
@@ -598,8 +598,9 @@ func (w *WebGlCanvas) SetCursorMode(mode CursorMode) {
 	w.Window.SetInputMode(glfw.CursorMode, int(mode))
 }
 
+// SetCursorPos sets the cursor position in screen coordinates
 func (w *WebGlCanvas) SetCursorPos(x float64, y float64) {
-	w.Window.SetCursorPos(xpos, ypos)
+	w.Window.SetCursorPos(x, y)
 }
 
 // SetInputMode changes specified input to specified state

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -495,6 +495,14 @@ func (w *GlfwWindow) DisposeAllCustomCursors() {
 	w.lastCursorKey = CursorLast
 }
 
+func (w *GlfwWindow) SetCursorMode(mode CursorMode) {
+	w.Window.SetInputMode(glfw.CursorMode, int(mode))
+}
+
+func (w *GlfwWindow) SetCursorPos(xpos float64, ypos float64) {
+	w.Window.SetCursorPos(xpos, ypos)
+}
+
 // Center centers the window on the screen.
 //func (w *GlfwWindow) Center() {
 //

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -499,8 +499,8 @@ func (w *GlfwWindow) SetCursorMode(mode CursorMode) {
 	w.Window.SetInputMode(glfw.CursorMode, int(mode))
 }
 
-func (w *GlfwWindow) SetCursorPos(xpos float64, ypos float64) {
-	w.Window.SetCursorPos(xpos, ypos)
+func (w *GlfwWindow) SetCursorPos(x float64, y float64) {
+	w.Window.SetCursorPos(x, y)
 }
 
 // Center centers the window on the screen.

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -501,8 +501,8 @@ func (w *GlfwWindow) SetCursorMode(mode CursorMode) {
 }
 
 // SetCursorPos sets the cursor position in screen coordinates
-func (w *GlfwWindow) SetCursorPos(x float64, y float64) {
-	w.Window.SetCursorPos(x, y)
+func (w *GlfwWindow) SetCursorPos(x int, y int) {
+	w.Window.SetCursorPos(float64(x), float64(y))
 }
 
 // Center centers the window on the screen.

--- a/window/glfw.go
+++ b/window/glfw.go
@@ -495,10 +495,12 @@ func (w *GlfwWindow) DisposeAllCustomCursors() {
 	w.lastCursorKey = CursorLast
 }
 
+// SetCursorMode hides, disables, and returns the cursor back to normal depending on the mode provided
 func (w *GlfwWindow) SetCursorMode(mode CursorMode) {
 	w.Window.SetInputMode(glfw.CursorMode, int(mode))
 }
 
+// SetCursorPos sets the cursor position in screen coordinates
 func (w *GlfwWindow) SetCursorPos(x float64, y float64) {
 	w.Window.SetCursorPos(x, y)
 }

--- a/window/window.go
+++ b/window/window.go
@@ -37,6 +37,8 @@ type IWindow interface {
 	GetScale() (x float64, y float64)
 	CreateCursor(imgFile string, xhot, yhot int) (Cursor, error)
 	SetCursor(cursor Cursor)
+	SetCursorMode(mode CursorMode)
+	SetCursorPos(x float64, y float64)
 	DisposeAllCustomCursors()
 	Destroy()
 }

--- a/window/window.go
+++ b/window/window.go
@@ -38,7 +38,7 @@ type IWindow interface {
 	CreateCursor(imgFile string, xhot, yhot int) (Cursor, error)
 	SetCursor(cursor Cursor)
 	SetCursorMode(mode CursorMode)
-	SetCursorPos(x float64, y float64)
+	SetCursorPos(x int, y int)
 	DisposeAllCustomCursors()
 	Destroy()
 }


### PR DESCRIPTION
The mode types for the cursor are defined in window but did not have the functions to set the modes in glfw without using the glfw types directly.

Used int for the cursor position since it is in screen coordinates are whole numbers. This is consistent with the output of getting the screen size
```go
x, y := app.GetSize()
app.IWindow.SetCursorPos(x/2, y/2)
```