### PR TITLE
Fix gui titleless resize crash

### DIFF
--- a/gui/window.go
+++ b/gui/window.go
@@ -177,12 +177,20 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 			if w.overRight {
 				delta := cev.Xpos - (w.pospix.X + w.width)
 				newWidth := w.Width() + delta
-				w.SetWidth(math32.Max(newWidth, w.title.label.Width()+w.title.closeButton.Width()))
+				if w.title != nil {
+					w.SetWidth(math32.Max(newWidth, w.title.label.Width()+w.title.closeButton.Width()))
+				} else {
+					w.SetWidth(newWidth)
+				}
 			}
 			if w.overBottom {
 				delta := cev.Ypos - (w.pospix.Y + w.height)
 				newHeight := w.Height() + delta
-				w.SetHeight(math32.Max(newHeight, w.title.height))
+				if w.title != nil {
+					w.SetHeight(math32.Max(newHeight, w.title.height))
+				} else {
+					w.SetHeight(newHeight)
+				}
 			}
 			if w.overLeft {
 				delta := cev.Xpos - w.pospix.X

--- a/gui/window.go
+++ b/gui/window.go
@@ -165,13 +165,16 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 			if w.overTop {
 				delta := cev.Ypos - w.pospix.Y
 				newHeight := w.Height() - delta
-				minHeight := w.title.height
+				var minHeight float32
+				if w.title != nil {
+					minHeight = w.title.height
+				}
 				if newHeight >= minHeight {
 					w.SetPositionY(w.Position().Y + delta)
 					w.SetHeight(math32.Max(newHeight, minHeight))
 				} else {
 					w.SetPositionY(w.Position().Y + w.Height() - minHeight)
-					w.SetHeight(w.title.height)
+					w.SetHeight(minHeight)
 				}
 			}
 			if w.overRight {
@@ -195,7 +198,10 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 			if w.overLeft {
 				delta := cev.Xpos - w.pospix.X
 				newWidth := w.Width() - delta
-				minWidth := w.title.label.Width() + w.title.closeButton.Width()
+				var minWidth float32
+				if w.title != nil {
+					minWidth = w.title.label.Width() + w.title.closeButton.Width()
+				}
 				if newWidth >= minWidth {
 					w.SetPositionX(w.Position().X + delta)
 					w.SetWidth(math32.Max(newWidth, minWidth))


### PR DESCRIPTION
Resizing a titleless gui window both horizontally and vertically causes a sigsegv due to accessing a nil title.

The top and left side resizing is still very broken, but this at least fixes the sigsegv panics

The titleless errors can be seen in the g3nd demo gui.window the first window is a titleless window that causes the crashes

This fixes https://github.com/g3n/engine/issues/94