### PR TITLE
Adding String() functions to the math32

### DIFF
--- a/math32/box2.go
+++ b/math32/box2.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Box2 represents a 2D bounding box defined by two points:
 // the point with minimum coordinates and the point with maximum coordinates.
 type Box2 struct {
@@ -225,4 +229,10 @@ func (b *Box2) Translate(offset *Vector2) *Box2 {
 func (b *Box2) Equals(other *Box2) bool {
 
 	return other.min.Equals(&b.min) && other.max.Equals(&b.max)
+}
+
+// String returns a formatted string of min and max
+func (b *Box2) String() string {
+
+	return fmt.Sprintf("(Min: %s, Max: %s)", b.min.String(), b.max.String())
 }

--- a/math32/box3.go
+++ b/math32/box3.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Box3 represents a 3D bounding box defined by two points:
 // the point with minimum coordinates and the point with maximum coordinates.
 type Box3 struct {
@@ -287,4 +291,10 @@ func (b *Box3) Equals(other *Box3) bool {
 func (b *Box3) Clone() *Box3 {
 
 	return NewBox3(&b.Min, &b.Max)
+}
+
+// String returns a formatted string of min and max
+func (b *Box3) String() string {
+
+	return fmt.Sprintf("(Min: %s, Max: %s)", b.Min.String(), b.Max.String())
 }

--- a/math32/color.go
+++ b/math32/color.go
@@ -5,8 +5,8 @@
 package math32
 
 import (
-	"strings"
 	"fmt"
+	"strings"
 )
 
 // Color describes an RGB color

--- a/math32/color.go
+++ b/math32/color.go
@@ -6,6 +6,7 @@ package math32
 
 import (
 	"strings"
+	"fmt"
 )
 
 // Color describes an RGB color
@@ -295,4 +296,10 @@ var mapColorNames = map[string]Color{
 	"whitesmoke":           {0.961, 0.961, 0.961},
 	"yellow":               {1.000, 1.000, 0.000},
 	"yellowgreen":          {0.604, 0.804, 0.196},
+}
+
+// String returns rgb values converted to a string
+func (c *Color) String() string {
+
+	return fmt.Sprintf("(R: %f, G: %f, B: %f)", c.R, c.G, c.B)
 }

--- a/math32/color4.go
+++ b/math32/color4.go
@@ -6,6 +6,7 @@ package math32
 
 import (
 	"strings"
+	"fmt"
 )
 
 // Color4 describes an RGBA color
@@ -112,4 +113,10 @@ func (c *Color4) FromColor(other *Color, alpha float32) {
 func (c *Color4) ToColor() Color {
 
 	return Color{c.R, c.G, c.B}
+}
+
+// String returns rgba values converted to a string
+func (c *Color4) String() string {
+
+	return fmt.Sprintf("(R: %f, G: %f, B: %f, A: %f)", c.R, c.G, c.B, c.A)
 }

--- a/math32/color4.go
+++ b/math32/color4.go
@@ -5,8 +5,8 @@
 package math32
 
 import (
-	"strings"
 	"fmt"
+	"strings"
 )
 
 // Color4 describes an RGBA color

--- a/math32/line3.go
+++ b/math32/line3.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Line3 represents a 3D line segment defined by a start and an end point.
 type Line3 struct {
 	start Vector3
@@ -98,3 +102,10 @@ func (l *Line3) Clone() *Line3 {
 
 	return NewLine3(&l.start, &l.end)
 }
+
+// String returns a formatted string of start and end
+func (l *Line3) String() string {
+
+    return fmt.Sprintf("(Start: %s, End: %s)", l.start.String(), l.end.String())
+}
+

--- a/math32/line3.go
+++ b/math32/line3.go
@@ -106,6 +106,5 @@ func (l *Line3) Clone() *Line3 {
 // String returns a formatted string of start and end
 func (l *Line3) String() string {
 
-    return fmt.Sprintf("(Start: %s, End: %s)", l.start.String(), l.end.String())
+	return fmt.Sprintf("(Start: %s, End: %s)", l.start.String(), l.end.String())
 }
-

--- a/math32/quaternion.go
+++ b/math32/quaternion.go
@@ -269,7 +269,7 @@ func (q *Quaternion) Normalize() *Quaternion {
 // Returns pointer to this updated quaternion.
 func (q *Quaternion) NormalizeFast() *Quaternion {
 
-	f := (3.0-(q.X*q.X + q.Y*q.Y + q.Z*q.Z + q.W*q.W))/2.0
+	f := (3.0 - (q.X*q.X + q.Y*q.Y + q.Z*q.Z + q.W*q.W)) / 2.0
 	if f == 0 {
 		q.X = 0
 		q.Y = 0
@@ -350,9 +350,9 @@ func (q *Quaternion) Slerp(other *Quaternion, t float32) *Quaternion {
 		return q
 	}
 
-	sqrSinHalfTheta := 1.0 - cosHalfTheta * cosHalfTheta
+	sqrSinHalfTheta := 1.0 - cosHalfTheta*cosHalfTheta
 	if sqrSinHalfTheta < 0.001 {
-		s := 1-t
+		s := 1 - t
 		q.W = s*w + t*q.W
 		q.X = s*x + t*q.X
 		q.Y = s*y + t*q.Y
@@ -360,8 +360,8 @@ func (q *Quaternion) Slerp(other *Quaternion, t float32) *Quaternion {
 		return q.Normalize()
 	}
 
-	sinHalfTheta := Sqrt( sqrSinHalfTheta )
-	halfTheta := Atan2( sinHalfTheta, cosHalfTheta )
+	sinHalfTheta := Sqrt(sqrSinHalfTheta)
+	halfTheta := Atan2(sinHalfTheta, cosHalfTheta)
 	ratioA := Sin((1-t)*halfTheta) / sinHalfTheta
 	ratioB := Sin(t*halfTheta) / sinHalfTheta
 

--- a/math32/quaternion.go
+++ b/math32/quaternion.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Quaternion is quaternion with X,Y,Z and W components.
 type Quaternion struct {
 	X float32
@@ -402,4 +406,10 @@ func (q *Quaternion) ToArray(array []float32, offset int) []float32 {
 func (q *Quaternion) Clone() *Quaternion {
 
 	return NewQuaternion(q.X, q.Y, q.Z, q.W)
+}
+
+// String returns a formatted string of X, Y, Z, W
+func (q *Quaternion) String() string {
+
+	return fmt.Sprintf("(%f, %f, %f, %f)", q.X, q.Y, q.Z, q.W)
 }

--- a/math32/ray.go
+++ b/math32/ray.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Ray represents an oriented 3D line segment defined by an origin point and a direction vector.
 type Ray struct {
 	origin    Vector3
@@ -508,4 +512,10 @@ func (ray *Ray) Equals(other *Ray) bool {
 func (ray *Ray) Clone() *Ray {
 
 	return NewRay(&ray.origin, &ray.direction)
+}
+
+// String returns a formatted string of origin and direction
+func (ray *Ray) String() string {
+
+	return fmt.Sprintf("(Origin: %s, Direction: %s)", ray.origin.String(), ray.direction.String())
 }

--- a/math32/sphere.go
+++ b/math32/sphere.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Sphere represents a 3D sphere defined by its center point and a radius
 type Sphere struct {
 	Center Vector3 // center of the sphere
@@ -145,4 +149,10 @@ func (s *Sphere) Translate(offset *Vector3) *Sphere {
 
 	s.Center.Add(offset)
 	return s
+}
+
+// String returns a formatted string of center and radius
+func (s *Sphere) String() string {
+
+	return fmt.Sprintf("(Center: %s, Radius: %f)", s.Center, s.Radius)
 }

--- a/math32/triangle.go
+++ b/math32/triangle.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Triangle represents a triangle made of three vertices.
 type Triangle struct {
 	a Vector3
@@ -188,4 +192,10 @@ func (t *Triangle) Equals(triangle *Triangle) bool {
 func (t *Triangle) Clone(triangle *Triangle) *Triangle {
 
 	return NewTriangle(nil, nil, nil).Copy(t)
+}
+
+// String returns a formatted string of the triangle.
+func (t *Triangle) String() string {
+
+	return fmt.Sprintf("(%s, %s, %s)", t.a, t.b, t.c)
 }

--- a/math32/vector2.go
+++ b/math32/vector2.go
@@ -414,4 +414,3 @@ func (v *Vector2) String() string {
 
 	return fmt.Sprintf("(%f, %f)", v.X, v.Y)
 }
-

--- a/math32/vector2.go
+++ b/math32/vector2.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Vector2 is a 2D vector/point with X and Y components.
 type Vector2 struct {
 	X float32
@@ -404,3 +408,10 @@ func (v *Vector2) InTriangle(p0, p1, p2 *Vector2) bool {
 
 	return s >= 0 && t >= 0 && (s+t) < 2*A*sign
 }
+
+// String returns x,y as a formatted string
+func (v *Vector2) String() string {
+
+	return fmt.Sprintf("(%f, %f)", v.X, v.Y)
+}
+

--- a/math32/vector3.go
+++ b/math32/vector3.go
@@ -646,12 +646,12 @@ func (v *Vector3) SetFromQuaternion(q *Quaternion) *Vector3 {
 // RandomTangents computes and returns two arbitrary tangents to the vector.
 func (v *Vector3) RandomTangents() (*Vector3, *Vector3) {
 
-	t1 := NewVector3(0,0,0)
-	t2 := NewVector3(0,0,0)
+	t1 := NewVector3(0, 0, 0)
+	t2 := NewVector3(0, 0, 0)
 	length := v.Length()
 	if length > 0 {
 		n := NewVector3(v.X/length, v.Y/length, v.Z/length)
-		randVec := NewVector3(0,0,0)
+		randVec := NewVector3(0, 0, 0)
 		if Abs(n.X) < 0.9 {
 			randVec.SetX(1)
 			t1.CrossVectors(n, randVec)
@@ -675,10 +675,10 @@ func (v *Vector3) RandomTangents() (*Vector3, *Vector3) {
 // AlmostEquals returns whether the vector is almost equal to another vector within the specified tolerance.
 func (v *Vector3) AlmostEquals(other *Vector3, tolerance float32) bool {
 
-	if (Abs(v.X - other.X) < tolerance) &&
-		(Abs(v.Y - other.Y) < tolerance) &&
-		(Abs(v.Z - other.Z) < tolerance) {
-			return true
+	if (Abs(v.X-other.X) < tolerance) &&
+		(Abs(v.Y-other.Y) < tolerance) &&
+		(Abs(v.Z-other.Z) < tolerance) {
+		return true
 	}
 	return false
 }

--- a/math32/vector3.go
+++ b/math32/vector3.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Vector3 is a 3D vector/point with X, Y and Z components.
 type Vector3 struct {
 	X float32
@@ -677,4 +681,10 @@ func (v *Vector3) AlmostEquals(other *Vector3, tolerance float32) bool {
 			return true
 	}
 	return false
+}
+
+// String returns x,y,z as a formatted string
+func (v *Vector3) String() string {
+
+	return fmt.Sprintf("(%f, %f, %f)", v.X, v.Y, v.Z)
 }

--- a/math32/vector4.go
+++ b/math32/vector4.go
@@ -4,6 +4,10 @@
 
 package math32
 
+import (
+	"fmt"
+)
+
 // Vector4 is a vector/point in homogeneous coordinates with X, Y, Z and W components.
 type Vector4 struct {
 	X float32
@@ -630,3 +634,11 @@ func (v *Vector4) Clone() *Vector4 {
 
 	return NewVector4(v.X, v.Y, v.Z, v.W)
 }
+
+
+// String returns x,y,z,w as a formatted string
+func (v *Vector4) String() string {
+
+	return fmt.Sprintf("(%f, %f, %f, %f)", v.X, v.Y, v.Z, v.W)
+}
+

--- a/math32/vector4.go
+++ b/math32/vector4.go
@@ -635,10 +635,8 @@ func (v *Vector4) Clone() *Vector4 {
 	return NewVector4(v.X, v.Y, v.Z, v.W)
 }
 
-
 // String returns x,y,z,w as a formatted string
 func (v *Vector4) String() string {
 
 	return fmt.Sprintf("(%f, %f, %f, %f)", v.X, v.Y, v.Z, v.W)
 }
-


### PR DESCRIPTION
I had a need for this as I was setting the name of some mesh's to the Vector2 that represented the ordering they were in. It seemed more appropriate to have a String() function on it than doing the formatting in every case where you just want a simple string of the vector. Added outputs to the other math32 types that seemed appropriate for consistency.

Note: When I ran fmt on math32 to make sure I didnt have any formatting problems it fixed some other formatting that didn't relate to my changes in a few files, let me know if I should split those out into a separate PR