### PR TITLE
Fix gui resize glitch

### DIFF
--- a/gui/panel.go
+++ b/gui/panel.go
@@ -497,7 +497,6 @@ func (p *Panel) MinHeight() float32 {
 
 // Pospix returns this panel absolute coordinate in pixels
 func (p *Panel) Pospix() math32.Vector3 {
-
 	return p.pospix
 }
 

--- a/gui/window.go
+++ b/gui/window.go
@@ -177,12 +177,20 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 			if w.overRight {
 				delta := cev.Xpos - (w.pospix.X + w.width)
 				newWidth := w.Width() + delta
-				w.SetWidth(math32.Max(newWidth, w.title.label.Width()+w.title.closeButton.Width()))
+				if w.title != nil {
+					w.SetWidth(math32.Max(newWidth, w.title.label.Width()+w.title.closeButton.Width()))
+				} else {
+					w.SetWidth(newWidth)
+				}
 			}
 			if w.overBottom {
 				delta := cev.Ypos - (w.pospix.Y + w.height)
 				newHeight := w.Height() + delta
-				w.SetHeight(math32.Max(newHeight, w.title.height))
+				if w.title != nil {
+					w.SetHeight(math32.Max(newHeight, w.title.height))
+				} else {
+					w.SetHeight(newHeight)
+				}
 			}
 			if w.overLeft {
 				delta := cev.Xpos - w.pospix.X

--- a/gui/window.go
+++ b/gui/window.go
@@ -176,6 +176,7 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 					w.SetPositionY(w.Position().Y + w.Height() - minHeight)
 					w.SetHeight(minHeight)
 				}
+				w.UpdateMatrixWorld()
 			}
 			if w.overRight {
 				delta := cev.Xpos - (w.pospix.X + w.width)
@@ -209,6 +210,7 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 					w.SetPositionX(w.Position().X + w.Width() - minWidth)
 					w.SetWidth(minWidth)
 				}
+				w.UpdateMatrixWorld()
 			}
 		} else {
 			// Obtain cursor position relative to window

--- a/gui/window.go
+++ b/gui/window.go
@@ -165,13 +165,16 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 			if w.overTop {
 				delta := cev.Ypos - w.pospix.Y
 				newHeight := w.Height() - delta
-				minHeight := w.title.height
+				var minHeight float32
+				if w.title != nil {
+					minHeight = w.title.height
+				}
 				if newHeight >= minHeight {
 					w.SetPositionY(w.Position().Y + delta)
 					w.SetHeight(math32.Max(newHeight, minHeight))
 				} else {
 					w.SetPositionY(w.Position().Y + w.Height() - minHeight)
-					w.SetHeight(w.title.height)
+					w.SetHeight(minHeight)
 				}
 			}
 			if w.overRight {
@@ -195,7 +198,10 @@ func (w *Window) onCursor(evname string, ev interface{}) {
 			if w.overLeft {
 				delta := cev.Xpos - w.pospix.X
 				newWidth := w.Width() - delta
-				minWidth := w.title.label.Width() + w.title.closeButton.Width()
+				var minWidth float32
+				if w.title != nil {
+					minWidth = w.title.label.Width() + w.title.closeButton.Width()
+				}
 				if newWidth >= minWidth {
 					w.SetPositionX(w.Position().X + delta)
 					w.SetWidth(math32.Max(newWidth, minWidth))


### PR DESCRIPTION
When resizing gui windows on either the left or top sides it would glitch out very badly and jump all around the screen due to the position change in addition to resizing. A call to UpdateWorldMatrix after setting the position fixes this and the windows resize smoothly in all directions now.

This PR also includes my changes from https://github.com/g3n/engine/pull/152 since they are required to test on the titleless windows