### PR TITLE
gui.Window added remove method

### DIFF
--- a/gui/window.go
+++ b/gui/window.go
@@ -16,7 +16,7 @@ import (
  +-------------------------------------+---+
  |              Title panel            | X |
  +-------------------------------------+---+
- |  Content panel                          |
+ |  Client (content) panel                 |
  |  +-----------------------------------+  |
  |  |                                   |  |
  |  |                                   |  |
@@ -35,7 +35,7 @@ type Window struct {
 	Panel       // Embedded Panel
 	styles      *WindowStyles
 	title       *WindowTitle // internal optional title panel
-	client      Panel        // internal client panel
+	client      Panel        // internal client (content) panel
 	resizable   bool         // Specifies whether the window is resizable
 	drag        bool         // Whether the mouse buttons is pressed (i.e. when dragging)
 	dragPadding float32      // Extra width used to resize (in addition to border sizes)
@@ -121,6 +121,11 @@ func (w *Window) Add(ichild IPanel) *Window {
 
 	w.client.Add(ichild)
 	return w
+}
+
+// Removes a child from the client (content) panel
+func (w *Window) Remove(ichild IPanel) bool {
+	return w.client.Remove(ichild)
 }
 
 // SetLayout sets the layout of the client panel.


### PR DESCRIPTION
Since the client (content) panel is not exposed, it was impossible to remove children from the client.

This will override the inherited method from Panel, it wraps the `(*Window).client.Remove(IPanel)` call, and works like ` (*Window).Add(IPanel)` which is a wrapper for `(*Window).client.Add(IPanel)`  https://github.com/g3n/engine/blob/d46afd9929b6d971e0259589e8a3a973f9f8425a/gui/window.go#L120-L125

Also minor doc clarifications