### PR TITLE
Add color support to logger console on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	github.com/mattn/go-colorable v0.1.6
 	golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,15 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 h1:QbL/5oDUmRBzO9/Z7Seo
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
+github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a h1:gHevYm0pO4QUbwy8Dmdr01R5r1BuKtfYqRqF0h/Cbh0=
 golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/util/logger/console.go
+++ b/util/logger/console.go
@@ -5,7 +5,9 @@
 package logger
 
 import (
-	"os"
+	"io"
+
+	"github.com/mattn/go-colorable"
 )
 
 // Ansi terminal color codes
@@ -40,7 +42,7 @@ var colorMap = map[int]string{
 
 // Console is a console writer used for logging.
 type Console struct {
-	writer *os.File
+	writer io.Writer
 	color  bool
 }
 
@@ -48,8 +50,7 @@ type Console struct {
 // If color is true, this writer uses Ansi codes to write
 // log messages in color accordingly to its level.
 func NewConsole(color bool) *Console {
-
-	return &Console{os.Stdout, color}
+	return &Console{colorable.NewColorableStdout(), color}
 }
 
 // Write writes the provided logger event to the console.


### PR DESCRIPTION
Fixes https://github.com/g3n/engine/issues/179

`NewColorableStdout()` from https://github.com/mattn/go-colorable wraps os.Stdout to handle ANSI color sequences on Windows. On other platforms os.Stdout is passed as is.