### PR TITLE
Fixed WASM build error: texture2D.go:356:6: gs.CompressedTexImage2D undefined

### DIFF
--- a/gls/gls-browser.go
+++ b/gls/gls-browser.go
@@ -663,6 +663,12 @@ func (gs *GLS) TexImage2D(target uint32, level int32, iformat int32, width int32
 	dataTA.Release()
 }
 
+// CompressedTexImage2D specifies a two-dimensional compressed texture image.
+func (gs *GLS) CompressedTexImage2D(target uint32, level uint32, iformat uint32, width int32, height int32, size int32, data interface{}) {
+
+	// todo
+}
+
 // TexParameteri sets the specified texture parameter on the specified texture.
 func (gs *GLS) TexParameteri(target uint32, pname uint32, param int32) {
 


### PR DESCRIPTION
I wasn't able to build wasm using Go 1.12.5.