### PR TITLE
Support size and title in app-desktop

### DIFF
--- a/app/app-desktop.go
+++ b/app/app-desktop.go
@@ -35,6 +35,10 @@ type Application struct {
 
 // App returns the Application singleton, creating it the first time.
 func App() *Application {
+	return AppSized(width, height, title)
+}
+
+func AppSized(width, height int, title string) *Application {
 
 	// Return singleton if already created
 	if a != nil {


### PR DESCRIPTION
This enables one to establish dimensions and title when the singleton is initialized:

```
myApp := app.App(2560, 1440, "My G3N app"),
```