### PR TITLE
simple cast enough to convert

### DIFF
--- a/math32/array.go
+++ b/math32/array.go
@@ -209,7 +209,7 @@ func (a ArrayF32) SetColor4(pos int, v *Color4) {
 // ToFloat32 converts this array to an array of float32
 func (a ArrayF32) ToFloat32() []float32 {
 
-	return (*[1 << 27]float32)(unsafe.Pointer(&a[0]))[:len(a)]
+	return a
 }
 
 // ArrayU32 is a slice of uint32 with additional convenience methods
@@ -249,5 +249,5 @@ func (a *ArrayU32) Append(v ...uint32) {
 // ToUint32 converts this array to an array of uint32
 func (a ArrayU32) ToUint32() []uint32 {
 
-	return (*[1 << 27]uint32)(unsafe.Pointer(&a[0]))[:len(a)]
+	return a
 }


### PR DESCRIPTION
Discovered this unnecessary tweak while using very large VBO . 
A simple cast is sufficient since ArrayU32 and ArrayF32 **are** []uint32 and []float32, respectively 