### PR TITLE
fix issue #216

### DIFF
--- a/graphic/graphic.go
+++ b/graphic/graphic.go
@@ -207,7 +207,7 @@ func (gr *Graphic) GetMaterial(vpos int) material.IMaterial {
 		if gmat.count == 0 {
 			return gmat.imat
 		}
-		if gmat.start >= vpos && gmat.start+gmat.count <= vpos {
+		if gmat.start <= vpos && gmat.start+gmat.count >= vpos {
 			return gmat.imat
 		}
 	}


### PR DESCRIPTION
The previous line had its <= and >= switched, so any .GetMaterial call on an object with multiple materials returned nil.