### PR TITLE
Enable access to material's textures as discussed in PR #190

### DIFF
--- a/material/material.go
+++ b/material/material.go
@@ -375,3 +375,9 @@ func (mat *Material) TextureCount() int {
 
 	return len(mat.textures)
 }
+
+// Textures returns a slice with this material's textures
+func (mat *Material) Textures() []*texture.Texture2D {
+
+	return mat.textures
+}

--- a/texture/texture2D.go
+++ b/texture/texture2D.go
@@ -142,6 +142,12 @@ func (t *Texture2D) Dispose() {
 	}
 }
 
+// TexName returns the texture handle for the texture
+func (t *Texture2D) TexName() uint32 {
+
+	return t.texname
+}
+
 // SetUniformNames sets the names of the uniforms in the shader for sampler and texture info.
 func (t *Texture2D) SetUniformNames(sampler, info string) {
 


### PR DESCRIPTION
In #190 it was requested to make a public method to access the material texture property instead of making the property public. This PR adds the TexName() method from #190 and a Texture() method on materials.