### PR TITLE
Make Node.Remove safer for concurrency

### DIFF
--- a/core/node.go
+++ b/core/node.go
@@ -418,9 +418,7 @@ func (n *Node) Remove(ichild INode) bool {
 
 	for pos, current := range n.children {
 		if current == ichild {
-			copy(n.children[pos:], n.children[pos+1:])
-			n.children[len(n.children)-1] = nil
-			n.children = n.children[:len(n.children)-1]
+			n.children = append(n.children[:pos], n.children[pos+1:]...)
 			ichild.GetNode().parent = nil
 			n.Dispatch(OnDescendant, nil)
 			return true


### PR DESCRIPTION
When running an application and calling `Node.Remove` concurrently, engine methods were frequently receiving a slice of children with a nil pointer.

This PR removes the step from `Node.Remove` that sets a pointer to nil, resolving those errors. It also seems to be faster according to my benchmarks.