### PR TITLE
Add Apple silicon cgo flags

### DIFF
--- a/audio/al/al.go
+++ b/audio/al/al.go
@@ -6,14 +6,16 @@
 // The OpenAL documentation can be accessed at https://openal.org/documentation/
 package al
 
-// #cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/local/opt/openal-soft/include/AL -I/usr/include/AL
-// #cgo freebsd  CFLAGS:  -DGO_FREEBSD -I/usr/local/include/AL
-// #cgo linux    CFLAGS:  -DGO_LINUX   -I/usr/include/AL
-// #cgo windows  CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/openal-soft-1.18.2/include/AL
-// #cgo darwin   LDFLAGS: -L/usr/local/opt/openal-soft/lib -lopenal
-// #cgo freebsd  LDFLAGS: -L/usr/local/lib -lopenal
-// #cgo linux    LDFLAGS: -lopenal
-// #cgo windows  LDFLAGS: -L${SRCDIR}/../windows/bin -lOpenAL32
+// #cgo darwin,amd64  CFLAGS:  -DGO_DARWIN  -I/usr/local/opt/openal-soft/include/AL -I/usr/include/AL
+// #cgo darwin,arm64  CFLAGS:  -DGO_DARWIN  -I/opt/homebrew/opt/openal-soft/include/AL
+// #cgo freebsd       CFLAGS:  -DGO_FREEBSD -I/usr/local/include/AL
+// #cgo linux         CFLAGS:  -DGO_LINUX   -I/usr/include/AL
+// #cgo windows       CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/openal-soft-1.18.2/include/AL
+// #cgo darwin,amd64  LDFLAGS: -L/usr/local/opt/openal-soft/lib -lopenal
+// #cgo darwin,arm64  LDFLAGS: -L/opt/homebrew/opt/openal-soft/lib -lopenal
+// #cgo freebsd       LDFLAGS: -L/usr/local/lib -lopenal
+// #cgo linux         LDFLAGS: -lopenal
+// #cgo windows       LDFLAGS: -L${SRCDIR}/../windows/bin -lOpenAL32
 // #include <stdlib.h>
 // #include "al.h"
 // #include "alc.h"

--- a/audio/ov/vorbisfile.go
+++ b/audio/ov/vorbisfile.go
@@ -6,14 +6,16 @@
 // The libvorbisfile C API reference is at: https://xiph.org/vorbis/doc/vorbisfile/reference.html
 package ov
 
-// #cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis -I/usr/local/include/vorbis
-// #cgo freebsd  CFLAGS:  -DGO_FREEBSD -I/usr/include/vorbis -I/usr/local/include/vorbis
-// #cgo linux    CFLAGS:  -DGO_LINUX   -I/usr/include/vorbis
-// #cgo windows  CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/libvorbis-1.3.5/include/vorbis -I${SRCDIR}/../windows/libogg-1.3.3/include
-// #cgo darwin   LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbisfile
-// #cgo freebsd  LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbisfile
-// #cgo linux    LDFLAGS: -lvorbisfile
-// #cgo windows  LDFLAGS: -L${SRCDIR}/../windows/bin -llibvorbisfile
+// #cgo darwin,amd64  CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis -I/usr/local/include/vorbis
+// #cgo darwin,arm64  CFLAGS:  -DGO_DARWIN  -I/opt/homebrew/include -I/opt/homebrew/include/vorbis
+// #cgo freebsd       CFLAGS:  -DGO_FREEBSD -I/usr/include/vorbis -I/usr/local/include/vorbis
+// #cgo linux         CFLAGS:  -DGO_LINUX   -I/usr/include/vorbis
+// #cgo windows       CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/libvorbis-1.3.5/include/vorbis -I${SRCDIR}/../windows/libogg-1.3.3/include
+// #cgo darwin,amd64  LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbisfile
+// #cgo darwin,arm64  LDFLAGS: -L/opt/homebrew/lib -lvorbisfile
+// #cgo freebsd       LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbisfile
+// #cgo linux         LDFLAGS: -lvorbisfile
+// #cgo windows       LDFLAGS: -L${SRCDIR}/../windows/bin -llibvorbisfile
 // #include <stdlib.h>
 // #include "vorbisfile.h"
 import "C"

--- a/audio/vorbis/vorbis.go
+++ b/audio/vorbis/vorbis.go
@@ -6,14 +6,16 @@
 // See API reference at: https://xiph.org/vorbis/doc/libvorbis/reference.html
 package vorbis
 
-// #cgo darwin   CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis -I/usr/local/include/vorbis
-// #cgo freebsd  CFLAGS:  -DGO_FREEBSD -I/usr/local/include/vorbis
-// #cgo linux    CFLAGS:  -DGO_LINUX   -I/usr/include/vorbis
-// #cgo windows  CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/libvorbis-1.3.5/include/vorbis -I${SRCDIR}/../windows/libogg-1.3.3/include
-// #cgo darwin   LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbis
-// #cgo freebsd  LDFLAGS: -L/usr/local/lib -lvorbis
-// #cgo linux    LDFLAGS: -lvorbis
-// #cgo windows  LDFLAGS: -L${SRCDIR}/../windows/bin -llibvorbis
+// #cgo darwin,amd64  CFLAGS:  -DGO_DARWIN  -I/usr/include/vorbis -I/usr/local/include/vorbis
+// #cgo darwin,arm64  CFLAGS:  -DGO_DARWIN  -I/opt/homebrew/include -I/opt/homebrew/include/vorbis
+// #cgo freebsd       CFLAGS:  -DGO_FREEBSD -I/usr/local/include/vorbis
+// #cgo linux         CFLAGS:  -DGO_LINUX   -I/usr/include/vorbis
+// #cgo windows       CFLAGS:  -DGO_WINDOWS -I${SRCDIR}/../windows/libvorbis-1.3.5/include/vorbis -I${SRCDIR}/../windows/libogg-1.3.3/include
+// #cgo darwin,amd64  LDFLAGS: -L/usr/lib -L/usr/local/lib -lvorbis
+// #cgo darwin,arm64  LDFLAGS: -L/opt/homebrew/lib -lvorbis
+// #cgo freebsd       LDFLAGS: -L/usr/local/lib -lvorbis
+// #cgo linux         LDFLAGS: -lvorbis
+// #cgo windows       LDFLAGS: -L${SRCDIR}/../windows/bin -llibvorbis
 // #include "codec.h"
 import "C"
 


### PR DESCRIPTION
What I did: I duplicated the darwin `#cgo` lines for both `CFLAGS` and `LDFLAGS`, and added `arm64` specific settings.
This makes 'go install' work on Apple silicon out of the box after installing the dependencies with brew on a freshly installed machine.

Hopefully fixes https://github.com/g3n/g3nd/issues/33

Before:
```
$ go install ./...
# github.com/g3n/engine/audio/al
audio/al/al.go:18:11: fatal error: 'al.h' file not found
 #include "al.h"
          ^~~~~~
1 error generated.
# github.com/g3n/engine/audio/vorbis
ld: library not found for -lvorbis
clang: error: linker command failed with exit code 1 (use -v to see invocation)
# github.com/g3n/engine/audio/ov
ld: library not found for -lvorbisfile
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
After
```
$ go install ./...
```

I also verified that switching to the `g3n/g3nd` folder and adding to `go.mod`
```
replace github.com/g3n/engine => ../g3n-engine
```
I was able to `go install` and run the demos.