### PR TITLE
Fix mouse coordinates in mouse events on Mac

### DIFF
--- a/window/glfw.go
+++ b/window/glfw.go
@@ -319,8 +319,8 @@ func Init(width, height int, title string) error {
 		xpos, ypos := x.GetCursorPos()
 		w.mouseEv.Button = MouseButton(button)
 		w.mouseEv.Mods = ModifierKey(mods)
-		w.mouseEv.Xpos = float32(xpos * w.scaleX)
-		w.mouseEv.Ypos = float32(ypos * w.scaleY)
+		w.mouseEv.Xpos = float32(xpos) //* float32(w.scaleX) TODO
+		w.mouseEv.Ypos = float32(ypos) //* float32(w.scaleY)
 		if action == glfw.Press {
 			w.Dispatch(OnMouseDown, &w.mouseEv)
 		} else if action == glfw.Release {


### PR DESCRIPTION
On Mac the initial mouse down coordinates for demos don’t get recorded properly and result in a «jump» when rotating or spanning:

![ko](https://user-images.githubusercontent.com/2386884/126784667-f105bbcf-1042-4bb2-9abb-ab9b5c6b0ba2.gif)

I noticed there is a PR that’s been open for quite a while about this: #109 but it changes code that’s not there anymore.
I also noticed the scaling has been removed at other locations: https://github.com/g3n/engine/blob/master/window/canvas.go#L411 https://github.com/g3n/engine/blob/master/window/canvas.go#L423 and https://github.com/g3n/engine/blob/master/window/canvas.go#L434 therefore I mimicked these comments in the change in the PR.

I realize a proper fix should probably do something like what #161 does, I’ll probably give it a try later as I noticed some HiDPI issues on my Windows.
But in the meanwhile this at least fixes MacOS (and doesn’t break on Windows as the scale is always 1):

![ok](https://user-images.githubusercontent.com/2386884/126785597-64d87eba-88e0-464a-83da-4ee06ff86148.gif)
