### PR TITLE
Fix core/node Clone

### DIFF
--- a/core/node.go
+++ b/core/node.go
@@ -142,6 +142,7 @@ func (n *Node) Clone() INode {
 	// TODO clone Dispatcher?
 	clone.Dispatcher.Initialize()
 
+	clone.inode = clone
 	clone.parent = n.parent
 	clone.name = n.name + " (Clone)" // TODO append count?
 	clone.loaderID = n.loaderID


### PR DESCRIPTION
In Clone() function , clone.Add(child) will raise an error, because there is no inode in clone itself .
