### PR TITLE
Fix alpha assignment in Color4.Set

### DIFF
--- a/math32/color4.go
+++ b/math32/color4.go
@@ -52,7 +52,7 @@ func (c *Color4) Set(r, g, b, a float32) *Color4 {
 	c.R = r
 	c.G = g
 	c.B = b
-	c.A = b
+	c.A = a
 	return c
 }
 


### PR DESCRIPTION
Stop Set() using the b parameter as the alpha component