### PR TITLE
Removed deprecated go get -u outside module

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ func main() {
   
 You can download and install `hellog3n` via:
     
-    go get -u github.com/g3n/demos/hellog3n
+    go install github.com/g3n/demos/hellog3n@latest
 
 For more complex demos please see the [G3N demo program](https://github.com/g3n/g3nd).
 

--- a/gui/assets/gen.go
+++ b/gui/assets/gen.go
@@ -2,7 +2,7 @@ package assets
 
 // To generate file with fonts binary data install "go-bindata" from:
 // https://github.com/go-bindata/go-bindata
-// > go get -u github.com/go-bindata/go-bindata/...
+// > go install github.com/go-bindata/go-bindata@latest
 
 //go:generate go-bindata -o data.go -pkg assets fonts cursors
 //go:generate g3nicodes -pkg icon icon/codepoints icon/icodes.go


### PR DESCRIPTION
This quick PR updates documentation on demo installation due to recent deprecation of `go get -u  <url>` outside golang repositories.

Find more about it here:
https://go.dev/doc/go-get-install-deprecation

If you find it minimally relevant, please consider merging.

Best regards.