### PR TITLE
Fix #280, blur font on darwin

### DIFF
--- a/gui/builder.go
+++ b/gui/builder.go
@@ -879,7 +879,7 @@ func AttribCheckIcons(b *Builder, am map[string]interface{}, fname string) error
 		if err != nil {
 			return b.err(am, fname, fmt.Sprintf("Invalid icon codepoint value/name:%v", parts[i]))
 		}
-		text += string(val)
+		text += string(rune(val))
 	}
 	am[fname] = text
 	return nil

--- a/gui/edit.go
+++ b/gui/edit.go
@@ -394,7 +394,7 @@ func (ed *Edit) CursorInput(s string) {
 
 	// Checks if new text exceeds edit width
 	width, _ := ed.Label.font.MeasureText(newText)
-	if float32(width)+editMarginX+float32(1) >= ed.Label.ContentWidth() {
+	if float32(width) / float32(ed.Label.font.ScaleX()) + editMarginX + float32(1) >= ed.Label.ContentWidth() {
 		return
 	}
 
@@ -412,7 +412,8 @@ func (ed *Edit) CursorInput(s string) {
 func (ed *Edit) redraw(caret bool) {
 
 	line := 0
-	ed.Label.setTextCaret(ed.text, editMarginX, ed.width, caret, line, ed.col, ed.selStart, ed.selEnd)
+	scaleX, _ := window.Get().GetScale()
+	ed.Label.setTextCaret(ed.text, editMarginX, int(float64(ed.width) * scaleX), caret, line, ed.col, ed.selStart, ed.selEnd)
 }
 
 // onKey receives subscribed key events
@@ -499,7 +500,7 @@ func (ed *Edit) handleMouse(mouseX float32, dragged bool) {
 	for nchars = 1; nchars <= text.StrCount(ed.text); nchars++ {
 		width, _ := ed.Label.font.MeasureText(text.StrPrefix(ed.text, nchars))
 		posx := mouseX - ed.pospix.X
-		if posx < editMarginX+float32(width) {
+		if posx < editMarginX + float32(float64(width) / ed.Label.font.ScaleX()) {
 			break
 		}
 	}
@@ -597,8 +598,9 @@ func (ed *Edit) applyStyle(s *EditStyle) {
 	//ed.Label.SetBgAlpha(s.BgAlpha)
 
 	if !ed.focus && len(ed.text) == 0 && len(ed.placeHolder) > 0 {
+		scaleX, _ := window.Get().GetScale()
 		ed.Label.SetColor4(&s.HolderColor)
-		ed.Label.setTextCaret(ed.placeHolder, editMarginX, ed.width, false, -1, ed.col, ed.selStart, ed.selEnd)
+		ed.Label.setTextCaret(ed.placeHolder, editMarginX, int(float64(ed.width) * scaleX), false, -1, ed.col, ed.selStart, ed.selEnd)
 	} else {
 		ed.Label.SetColor4(&s.FgColor)
 		ed.redraw(ed.focus)

--- a/gui/label.go
+++ b/gui/label.go
@@ -100,12 +100,12 @@ func (l *Label) SetText(text string) {
 	}
 
 	// Update label panel dimensions
-	width, height := textImage.Rect.Dx(), textImage.Rect.Dy()
+	width, height := float32(textImage.Rect.Dx()), float32(textImage.Rect.Dy())
 	if runtime.GOOS == "darwin" {
 		// since we enlarged the font texture for higher quality, we have to scale it back to it's original point size
 		width, height = width / 2, height / 2
 	}
-	l.Panel.SetContentSize(float32(width), float32(height))
+	l.Panel.SetContentSize(width, height)
 }
 
 // Text returns the label text.

--- a/gui/label.go
+++ b/gui/label.go
@@ -100,12 +100,12 @@ func (l *Label) SetText(text string) {
 	}
 
 	// Update label panel dimensions
-	width, height := float32(textImage.Rect.Dx()), float32(textImage.Rect.Dy())
+	width, height := textImage.Rect.Dx(), textImage.Rect.Dy()
 	if runtime.GOOS == "darwin" {
 		// since we enlarged the font texture for higher quality, we have to scale it back to it's original point size
 		width, height = width / 2, height / 2
 	}
-	l.Panel.SetContentSize(width, height)
+	l.Panel.SetContentSize(float32(width), float32(height))
 }
 
 // Text returns the label text.

--- a/gui/label.go
+++ b/gui/label.go
@@ -5,6 +5,8 @@
 package gui
 
 import (
+	"runtime"
+
 	"github.com/g3n/engine/gls"
 	"github.com/g3n/engine/math32"
 	"github.com/g3n/engine/text"
@@ -98,7 +100,12 @@ func (l *Label) SetText(text string) {
 	}
 
 	// Update label panel dimensions
-	l.Panel.SetContentSize(float32(textImage.Rect.Dx()), float32(textImage.Rect.Dy()))
+	width, height := float32(textImage.Rect.Dx()), float32(textImage.Rect.Dy())
+	if runtime.GOOS == "darwin" {
+		// since we enlarged the font texture for higher quality, we have to scale it back to it's original point size
+		width, height = width / 2, height / 2
+	}
+	l.Panel.SetContentSize(width, height)
 }
 
 // Text returns the label text.

--- a/gui/label.go
+++ b/gui/label.go
@@ -226,6 +226,9 @@ func (l *Label) setTextCaret(msg string, mx, width int, drawCaret bool, line, co
 	l.font.SetAttributes(&l.style.FontAttributes)
 	l.font.SetColor(&l.style.FgColor)
 
+	scaleX, scaleY := window.Get().GetScale()
+	l.font.SetScaleXY(scaleX, scaleY)
+
 	// Create canvas and draw text
 	_, height := l.font.MeasureText(msg)
 	canvas := text.NewCanvas(width, height, &l.style.BgColor)
@@ -244,6 +247,6 @@ func (l *Label) setTextCaret(msg string, mx, width int, drawCaret bool, line, co
 	l.tex.SetMinFilter(gls.NEAREST)
 
 	// Updates label panel dimensions
-	l.Panel.SetContentSize(float32(width), float32(height))
+	l.Panel.SetContentSize(float32(width) / float32(scaleX), float32(height) / float32(scaleY))
 	l.text = msg
 }

--- a/gui/label.go
+++ b/gui/label.go
@@ -5,12 +5,11 @@
 package gui
 
 import (
-	"runtime"
-
 	"github.com/g3n/engine/gls"
 	"github.com/g3n/engine/math32"
 	"github.com/g3n/engine/text"
 	"github.com/g3n/engine/texture"
+	"github.com/g3n/engine/window"
 )
 
 // Label is a panel which contains a texture with text.
@@ -85,6 +84,9 @@ func (l *Label) SetText(text string) {
 	l.font.SetAttributes(&l.style.FontAttributes)
 	l.font.SetColor(&l.style.FgColor)
 
+	scaleX, scaleY := window.Get().GetScale()
+	l.font.SetScaleXY(scaleX, scaleY)
+
 	// Create an image with the text
 	textImage := l.font.DrawText(text)
 
@@ -101,10 +103,8 @@ func (l *Label) SetText(text string) {
 
 	// Update label panel dimensions
 	width, height := float32(textImage.Rect.Dx()), float32(textImage.Rect.Dy())
-	if runtime.GOOS == "darwin" {
-		// since we enlarged the font texture for higher quality, we have to scale it back to it's original point size
-		width, height = width / 2, height / 2
-	}
+	// since we enlarged the font texture for higher quality, we have to scale it back to it's original point size
+	width, height = width / float32(scaleX), height / float32(scaleY)
 	l.Panel.SetContentSize(width, height)
 }
 

--- a/text/font.go
+++ b/text/font.go
@@ -21,21 +21,21 @@ import (
 // Font represents a TrueType font face.
 // Attributes must be set prior to drawing.
 type Font struct {
-	ttf     *truetype.Font // The TrueType font
-	face    font.Face      // The font face
-	attrib  FontAttributes // Internal attribute cache
-	fg      *image.Uniform // Text color cache
-	bg      *image.Uniform // Background color cache
-	scaleX, scaleY float64      // Scales of actual pixel/GL point, used for fix Retina Monitor
-	changed bool           // Whether attributes have changed and the font face needs to be recreated
+	ttf            *truetype.Font // The TrueType font
+	face           font.Face      // The font face
+	attrib         FontAttributes // Internal attribute cache
+	fg             *image.Uniform // Text color cache
+	bg             *image.Uniform // Background color cache
+	scaleX, scaleY float64        // Scales of actual pixel/GL point, used for fix Retina Monitor
+	changed        bool           // Whether attributes have changed and the font face needs to be recreated
 }
 
 // FontAttributes contains tunable attributes of a font.
 type FontAttributes struct {
-	PointSize      float64      // Point size of the font
-	DPI            float64      // Resolution of the font in dots per inch
-	LineSpacing    float64      // Spacing between lines (in terms of font height)
-	Hinting        font.Hinting // Font hinting
+	PointSize   float64      // Point size of the font
+	DPI         float64      // Resolution of the font in dots per inch
+	LineSpacing float64      // Spacing between lines (in terms of font height)
+	Hinting     font.Hinting // Font hinting
 }
 
 func (a *FontAttributes) newTTOptions(scaleX, scaleY float64) *truetype.Options {

--- a/text/font.go
+++ b/text/font.go
@@ -214,7 +214,6 @@ func (f *Font) Metrics() font.Metrics {
 func (f *Font) DrawText(text string) *image.RGBA {
 
 	width, height := f.MeasureText(text)
-	println(width, height)
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
 	draw.Draw(img, img.Bounds(), f.bg, image.ZP, draw.Src)
 	f.DrawTextOnImage(text, 0, 0, img)


### PR DESCRIPTION
Font's on retina will be blur cause Rentina have 2x DPI
Now we times the DPI by 2 when on darwin, and scale the Label panel by 0.5 to keep the original size
Since we scaled the panel size back, so it should not affect much on non-Rentina darwin
However, if you are using non-darwin with rentina monitor, issue https://github.com/g3n/engine/issues/280 will still happen, need a way to detect the monitor