### PR TITLE
Fix #301, race detector will failed with g3n

### DIFF
--- a/gls/glapi.c
+++ b/gls/glapi.c
@@ -3055,9 +3055,9 @@ void glVertexAttrib4usv(GLuint index, const GLushort *v) {
 	}
 }
 
-void glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer) {
+void glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLsizeiptr pointer) {
 
-	pglVertexAttribPointer(index, size, type, normalized, stride, pointer);
+	pglVertexAttribPointer(index, size, type, normalized, stride, (void*)(pointer));
 	if (checkError) {
 		GLenum err = pglGetError();
 		if (err != GL_NO_ERROR) {

--- a/gls/glcorearb.h
+++ b/gls/glcorearb.h
@@ -956,7 +956,7 @@ GLAPI void APIENTRY glVertexAttrib4sv (GLuint index, const GLshort *v);
 GLAPI void APIENTRY glVertexAttrib4ubv (GLuint index, const GLubyte *v);
 GLAPI void APIENTRY glVertexAttrib4uiv (GLuint index, const GLuint *v);
 GLAPI void APIENTRY glVertexAttrib4usv (GLuint index, const GLushort *v);
-GLAPI void APIENTRY glVertexAttribPointer (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer);
+GLAPI void APIENTRY glVertexAttribPointer (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLsizeiptr pointer);
 #endif
 #endif /* GL_VERSION_2_0 */
 

--- a/gls/gls-desktop.go
+++ b/gls/gls-desktop.go
@@ -812,7 +812,7 @@ func (gs *GLS) Uniform4fv(location int32, count int32, v *float32) {
 // VertexAttribPointer defines an array of generic vertex attribute data.
 func (gs *GLS) VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool, stride int32, offset uint32) {
 
-	C.glVertexAttribPointer(C.GLuint(index), C.GLint(size), C.GLenum(xtype), bool2c(normalized), C.GLsizei(stride), unsafe.Pointer(uintptr(offset)))
+	C.glVertexAttribPointer(C.GLuint(index), C.GLint(size), C.GLenum(xtype), bool2c(normalized), C.GLsizei(stride), C.GLsizeiptr(offset))
 }
 
 // Viewport sets the viewport.


### PR DESCRIPTION

- fix #301

Now we convert uint32 into C.GLsizeiptr first, then convert GLsizeiptr into *void inside C function, so the race detector will not failed anymore.
