### PR TITLE
fix: use IsNaN() instead of == NaN() comparison in Ray.IntersectPlane

### DIFF
--- a/math32/ray.go
+++ b/math32/ray.go
@@ -322,7 +322,7 @@ func (ray *Ray) IntersectPlane(plane *Plane, optionalTarget *Vector3) *Vector3 {
 
 	t := ray.DistanceToPlane(plane)
 
-	if t == NaN() {
+	if IsNaN(t) {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #164. NaN comparisons using == never work in IEEE 754 since NaN != NaN is always true. Use the existing IsNaN() function instead.