### PR TITLE
Fix sign of Box2.Size() and Box3.Size()

### DIFF
--- a/math32/box2.go
+++ b/math32/box2.go
@@ -99,7 +99,7 @@ func (b *Box2) Center(optionalTarget *Vector2) *Vector2 {
 	return result.AddVectors(&b.min, &b.max).MultiplyScalar(0.5)
 }
 
-// Size calculates the size of this bounding box: the vector  from
+// Size calculates the size of this bounding box: the vector from
 // its minimum point to its maximum point.
 // Store pointer to the calculated size into optionalTarget, if not nil,
 // and also returns it.
@@ -111,7 +111,7 @@ func (b *Box2) Size(optionalTarget *Vector2) *Vector2 {
 	} else {
 		result = optionalTarget
 	}
-	return result.SubVectors(&b.min, &b.max)
+	return result.SubVectors(&b.max, &b.min)
 }
 
 // ExpandByPoint may expand this bounding box to include the specified point.

--- a/math32/box3.go
+++ b/math32/box3.go
@@ -101,7 +101,7 @@ func (b *Box3) Center(optionalTarget *Vector3) *Vector3 {
 	return result.AddVectors(&b.Min, &b.Max).MultiplyScalar(0.5)
 }
 
-// Size calculates the size of this bounding box: the vector  from
+// Size calculates the size of this bounding box: the vector from
 // its minimum point to its maximum point.
 // Store pointer to the calculated size into optionalTarget, if not nil,
 // and also returns it.
@@ -113,7 +113,7 @@ func (b *Box3) Size(optionalTarget *Vector3) *Vector3 {
 	} else {
 		result = optionalTarget
 	}
-	return result.SubVectors(&b.Min, &b.Max)
+	return result.SubVectors(&b.Max, &b.Min)
 }
 
 // ExpandByPoint may expand this bounding box to include the specified point.


### PR DESCRIPTION
`Box2.Size()` and `Box3.Size()` both subtracted the vectors in the wrong order, so the results were always negative.

e.g. a `Box2` with points `(-1, 4)` and `(5,-3)` would have `min=(-1,-3)` and `max=(5,4)`, so a `Size()` of `(-6,-7)` before this change.